### PR TITLE
refactor(skills): reorganize using Claude Code native concepts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -309,6 +309,16 @@ This is reference-based (not discovery-based) for:
 
 ---
 
+## Protocol
+
+See **PROTOCOL.md** for detailed action classification tables:
+- Setup and Build mode actions
+- Agent categories and executor mappings
+- Triggerer semantics (event, user, self, parent, #index)
+- Passive constraints (rules and skills with activation points)
+
+---
+
 ## Human Intervention Points
 
 ### Arbiter Checkpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to ALTO.
 
 ## [Unreleased]
 
+### Added
+- **PROTOCOL.md** — Action classification and execution model:
+  - Classification axes (Input/Output/Process 1-5 scale)
+  - Agent categories table (impl, tester, reviewer, controller, planner, support)
+  - Column reference (Type, Executor, Triggerer)
+  - Setup and Build mode action tables with hierarchical indexing
+  - Passive Constraints with activation model (Soft/Strong/Where)
+  - Rules vs Skills comparison
+
+### Changed
+- **ARCHITECTURE.md** — Moved Component Classification to PROTOCOL.md, added reference
+- **claude-docs/subfolders/rules.md** — Added "Rules vs Skills: Activation Model" section:
+  - Activation types (Soft/Strong), where defined, when to use each
+  - Key insight: rules are suggestions, hooks are enforcement
+- **claude-docs/subfolders/skills.md** — Added "Skills vs Rules: Activation Model" section:
+  - Soft vs Strong activation diagram
+  - When to use each activation type
+- **claude-docs/subfolders/README.md** — Added comprehensive "Agents vs Rules vs Skills" comparison:
+  - Purpose & Propagation table
+  - Activation Model comparison (Loading, Activation, Context cost, Trigger)
+  - References to GitHub issues ([#8395](https://github.com/anthropics/claude-code/issues/8395), [#19635](https://github.com/anthropics/claude-code/issues/19635))
+
 ### Changed
 - **Skills reorganized using Claude Code native concepts** (Rules, Commands, Skills, Agents):
   - **Migrated to Rules** (`.claude/rules/`, always loaded at session start):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to ALTO.
 ## [Unreleased]
 
 ### Changed
+- **Skills reorganized using Claude Code native concepts** (Rules, Commands, Skills, Agents):
+  - **Migrated to Rules** (`.claude/rules/`, always loaded at session start):
+    - `scope-discipline.md` - Global constraint rule
+    - `prompt-writing.md` - Prompt writing discipline
+    - `formats/handoff.md` - Path-targeted for `runs/handoffs/**`
+    - `formats/task.md` - Path-targeted for `runs/tasks/**`
+    - `formats/review.md` - Path-targeted for `runs/review/**`
+  - **Converted to Command** (`.claude/commands/`, explicit `/invoke`):
+    - `alto-gitops.md` - Was deterministic+atomic agent, now explicit command
+  - **Removed from Skills** (migrated to rules):
+    - `handoff-writing`, `task-writing`, `review-writing`, `scope-discipline`, `prompt-writing`
+  - **Agent references updated**: All agents now reference `.claude/rules/formats/*.md` instead of `.claude/skills/*-writing/SKILL.md`
+  - **Deploy script updated**: `alto-deploy.sh` now copies rules and commands directories
+
+### Removed
+- `agents/alto-gitops.md` - Converted to command
+- `hooks/tool-use-record.py` - Deprecated stub (replaced by `tool-record.py`)
+- 5 skill directories migrated to rules: `scope-discipline`, `handoff-writing`, `task-writing`, `review-writing`, `prompt-writing`
+
+### Changed
 - **Documentation restructured** for distinct audiences:
   - `README.md` (~95 lines) — Minimal usage guide: highlights, quick start, modes, commands
   - `ARCHITECTURE.md` (~245 lines) — Human-readable design: models, lifecycle, state machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to ALTO.
 ## [Unreleased]
 
 ### Added
+- **Claude Code Knowledge Base** (`claude-code/knowledge-base/`) — AI-optimized documentation:
+  - 15 markdown files (~4160 lines total) covering all Claude Code extensibility features
+  - `index.md` — Navigation hub with feature matrix and selection guide
+  - `overview.md` — Context flow diagrams, lifecycle, "what affects what"
+  - Core features: `tools.md`, `settings.md`, `memory.md`, `permissions.md`
+  - Extensions: `rules.md`, `commands.md`, `skills.md`, `agents.md`, `hooks.md`
+  - Supporting: `mcp.md`, `plan-mode.md`, `output-styles.md`, `quick-reference.md`
+  - Design principles: hierarchical markdown, tables over prose, examples first
+- **ALTO Development Rules** (`rules/alto-development.md`) — 10 distilled rules for dev mode:
+  - Rule Placement (single agent vs multi-agent)
+  - Feature Selection Matrix (rule vs skill vs hook vs command)
+  - CLAUDE.md Size Limits (<300 lines, use file:line references)
+  - Provide Alternatives, Not Just Negatives
+  - Don't Use LLM for Linter Work
+  - Skill Activation Safety (disable-model-invocation for dangerous ops)
+  - Agent Path Restrictions (always specify allowed_paths)
+  - Hook Limitations Awareness (warn messages only reach user)
+  - Context Management in Multi-Agent Systems
+  - Prompt Writing Discipline
 - **PROTOCOL.md** — Action classification and execution model:
   - Classification axes (Input/Output/Process 1-5 scale)
   - Agent categories table (impl, tester, reviewer, controller, planner, support)

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,0 +1,204 @@
+# ALTO Protocol
+
+> Action classification and execution model for ALTO orchestration.
+
+---
+
+## Classification Axes
+
+Actions are classified along three axes (1-5 scale):
+
+| Axis | 1 | 2 | 3 | 4 | 5 |
+|------|---|---|---|---|---|
+| **Input** | None | Minimal | Partial | Significant | Full |
+| **Output** | Deterministic | Mostly Det. | Mixed | Mostly Judg. | Judgment |
+| **Process** | Atomic | Simple | Moderate | Complex | Compound |
+
+---
+
+## Agent Categories
+
+| Category | Agents | Purpose |
+|----------|--------|---------|
+| **impl** | alto-backend, alto-frontend | Write production code |
+| **tester** | alto-qa | Write tests |
+| **reviewer** | alto-reviewer | Quality gates |
+| **controller** | alto-arbiter | Checkpoint decisions |
+| **planner** | alto-planner | Create tasks |
+| **support** | alto-docs, code-simplifier, alto-feature-finder | Documentation, refactoring, analysis |
+
+> Agent .md files follow naming: `alto-{name}.md` (e.g., `alto-backend.md`, `alto-planner.md`)
+
+---
+
+## Column Reference
+
+### Type
+
+| Type | Description |
+|------|-------------|
+| `hook` | Python script triggered by Claude Code events |
+| `orchestrator` | Action defined in CLAUDE.md.{mode} template |
+| `agent` | Action executed by a spawned agent |
+| `skill` | Reusable procedure (can be active or passive) |
+| `rule` | Format constraint applied to agent output |
+
+### Executor
+
+| Type | Executor Value |
+|------|----------------|
+| `hook` | .py filename (e.g., `session-start.py`) |
+| `orchestrator` | `CLAUDE.md.build` or `CLAUDE.md.setup` |
+| `agent` | Category name (impl, planner, support, etc.) |
+| `skill` | Skill name (e.g., `alto-configure`) |
+| `rule` | Format file (e.g., `formats/handoff.md`) |
+
+### Triggerer
+
+| Value | Meaning |
+|-------|---------|
+| Event name | Claude Code hook event (SessionStart, PostToolUse, SubagentStop, etc.) |
+| `user` | Explicit user input |
+| `self` | The .md file's own execution flow |
+| `parent` | Orchestrator invokes this agent |
+| `#index` | Previous action's completion triggers this |
+
+---
+
+## Setup Mode Actions
+
+| # | Action | Type | Executor | Triggerer | Context | In | Out | Proc |
+|---|--------|------|----------|-----------|---------|:--:|:---:|:----:|
+| 1 | Initialize session | hook | session-start.py | SessionStart | project state | 2 | 1 | 1 |
+| 2 | Record tool usage | hook | tool-record.py | PostToolUse | tool call | 2 | 1 | 1 |
+| 3 | Record usage | hook | usage-record.py | Stop | session data | 2 | 1 | 1 |
+| 4 | Summarize session | hook | session-summary.py | SessionEnd | session data | 3 | 1 | 2 |
+| 5 | Configure settings | skill | alto-configure | user | alto.json | 2 | 3 | 3 |
+| 6 | Define feature | skill | alto-objective | user | user input | 3 | 3 | 3 |
+| 7 | Analyze codebase | agent | support | parent | objective.md | 4 | 4 | 3 |
+
+---
+
+## Build Mode Actions
+
+### Session Lifecycle
+
+| # | Action | Type | Executor | Triggerer | Context | In | Out | Proc |
+|---|--------|------|----------|-----------|---------|:--:|:---:|:----:|
+| 1 | Initialize session | hook | session-start.py | SessionStart | project state | 2 | 1 | 1 |
+| 2 | Record tool usage | hook | tool-record.py | PostToolUse | tool call | 2 | 1 | 1 |
+| 3 | Record usage | hook | usage-record.py | Stop | session data | 2 | 1 | 1 |
+| 4 | Summarize session | hook | session-summary.py | SessionEnd | session data | 3 | 1 | 2 |
+
+### Architecture Phase
+
+| # | Action | Type | Executor | Triggerer | Context | In | Out | Proc |
+|---|--------|------|----------|-----------|---------|:--:|:---:|:----:|
+| 10 | Explore & architect | orchestrator | CLAUDE.md.build | user | objective.md | 5 | 5 | 5 |
+| 10.1 | Read objective | orchestrator | CLAUDE.md.build | self | objective.md | 2 | 2 | 1 |
+| 10.2 | Analyze codebase | agent | support | parent | objective.md | 4 | 4 | 3 |
+| 10.3 | Write milestones | orchestrator | CLAUDE.md.build | #10.2 | analysis | 4 | 4 | 3 |
+| 10.4 | Write decisions | orchestrator | CLAUDE.md.build | #10.2 | analysis | 4 | 4 | 3 |
+
+### Planning Phase
+
+| # | Action | Type | Executor | Triggerer | Context | In | Out | Proc |
+|---|--------|------|----------|-----------|---------|:--:|:---:|:----:|
+| 20 | Plan tasks | agent | planner | parent | milestones | 4 | 4 | 4 |
+| 20.1 | Read milestones | agent | planner | self | milestones.md | 2 | 2 | 1 |
+| 20.2 | Create task files | agent | planner | #20.1 | task breakdown | 3 | 4 | 3 |
+| 20.3 | Format task file | rule | formats/task.md | #20.2 | task content | 2 | 2 | 1 |
+| 21 | Validate task | hook | task-validate.py | PostToolUse | task file | 2 | 1 | 1 |
+| 22 | Validate phase | hook | phase-validate.py | PostToolUse | state.json | 2 | 1 | 1 |
+
+### Execution Loop
+
+| # | Action | Type | Executor | Triggerer | Context | In | Out | Proc |
+|---|--------|------|----------|-----------|---------|:--:|:---:|:----:|
+| 30 | Check arbiter pending | orchestrator | CLAUDE.md.build | self | pending.json | 2 | 2 | 1 |
+| 31 | Assess checkpoint risk | agent | controller | parent | metrics, logs | 3 | 4 | 2 |
+| 32 | Decide block/continue | orchestrator | CLAUDE.md.build | #31 | assessment | 3 | 2 | 1 |
+| 33 | Pick next task | orchestrator | CLAUDE.md.build | #32 | state, tasks | 3 | 3 | 2 |
+| 34 | Invoke role agent | orchestrator | CLAUDE.md.build | #33 | task, context | 3 | 3 | 2 |
+| 35 | Schedule arbiter | hook | arbiter-scheduler.py | SubagentStop | metrics | 3 | 1 | 2 |
+| 36 | Block for human | orchestrator | CLAUDE.md.build | #32 | blocker info | 3 | 3 | 2 |
+| 37 | Resume from block | orchestrator | CLAUDE.md.build | user | human input | 3 | 4 | 2 |
+| 38 | Decide replan | orchestrator | CLAUDE.md.build | #33 | state, milestones | 3 | 3 | 2 |
+
+### Task Execution (Role Agent)
+
+| # | Action | Type | Executor | Triggerer | Context | In | Out | Proc |
+|---|--------|------|----------|-----------|---------|:--:|:---:|:----:|
+| 40 | Implement task | agent | impl | parent | task file | 4 | 5 | 5 |
+| 40.1 | Read task file | agent | impl | self | task file | 2 | 2 | 1 |
+| 40.2 | Read previous handoff | agent | impl | #40.1 | handoff file | 2 | 2 | 1 |
+| 40.3 | Write code | agent | impl | #40.2 | task context | 4 | 5 | 5 |
+| 40.4 | Run verification | agent | impl | #40.3 | verify steps | 2 | 2 | 2 |
+| 40.5 | Write handoff | agent | impl | #40.4 | impl summary | 3 | 3 | 2 |
+| 40.6 | Format handoff | rule | formats/handoff.md | #40.5 | handoff content | 2 | 2 | 1 |
+| 41 | Validate handoff | hook | handoff-validate.py | SubagentStop | handoff file | 2 | 1 | 1 |
+| 42 | Create handoff template | hook | handoff-template.py | PostToolUse | state.json | 2 | 1 | 1 |
+
+> **impl** = any implementer agent (alto-backend, alto-frontend). All follow the same execution pattern.
+
+### Post-Task Processing
+
+| # | Action | Type | Executor | Triggerer | Context | In | Out | Proc |
+|---|--------|------|----------|-----------|---------|:--:|:---:|:----:|
+| 50 | Assess code quality | agent | reviewer | parent | handoff, diff | 3 | 4 | 2 |
+| 50.1 | Format review | rule | formats/review.md | #50 | review content | 2 | 2 | 1 |
+| 51 | Validate review | hook | review-validate.py | SubagentStop | review file | 2 | 1 | 1 |
+| 52 | Decide approve/reject | orchestrator | CLAUDE.md.build | #50 | assessment | 3 | 3 | 1 |
+| 53 | Write tests | agent | tester | parent | handoff, impl | 4 | 4 | 4 |
+| 53.1 | Run tests | agent | tester | self | test files | 2 | 2 | 2 |
+| 53.2 | Fix test failures | agent | tester | #53.1 | test output | 3 | 4 | 3 |
+| 54 | Refactor code | agent | support | parent | handoff, files | 3 | 4 | 4 |
+| 55 | Write documentation | agent | support | parent | handoff, plan | 3 | 4 | 3 |
+| 56 | Execute git commit | agent | support | parent | staged files | 2 | 2 | 2 |
+| 57 | Record permissions | hook | permission-record.py | PermissionRequest | permission req | 2 | 1 | 1 |
+
+### Completion
+
+| # | Action | Type | Executor | Triggerer | Context | In | Out | Proc |
+|---|--------|------|----------|-----------|---------|:--:|:---:|:----:|
+| 60 | Mark task complete | orchestrator | CLAUDE.md.build | #56 | state.json | 2 | 2 | 1 |
+| 61 | Update state | orchestrator | CLAUDE.md.build | #60 | state.json | 2 | 2 | 1 |
+| 62 | Update DoD | orchestrator | CLAUDE.md.build | #61 | objective.md | 2 | 2 | 1 |
+| 63 | Complete feature | orchestrator | CLAUDE.md.build | #62 | state | 2 | 2 | 1 |
+| 64 | Enter debug mode | orchestrator | CLAUDE.md.build | user | user choice | 2 | 2 | 1 |
+
+---
+
+## Passive Constraints
+
+| Constraint | Type | Applies To | Where | Soft | Strong | Effect |
+|------------|------|------------|-------|------|--------|--------|
+| Scope discipline | skill | impl, tester | skills/scope-discipline/ | #40.3, #53 | — | Prevents out-of-scope work |
+| Path restrictions | rule | role agents | agents/*.md | — | — | Limits file access per agent |
+| Prompt writing | rule | orchestrator, agents | CLAUDE.md.* | — | — | Enforces explicit tool/path references |
+| Handoff format | rule | impl, reviewer | formats/handoff.md | — | #40.5, #50 | Structures agent output |
+| Task format | rule | planner | formats/task.md | — | #20.2 | Structures task files |
+| Review format | rule | reviewer | formats/review.md | — | #50 | Structures review output |
+| alto-configure | skill | orchestrator | skills/alto-configure/ | — | #5 | Configuration procedures |
+| alto-objective | skill | orchestrator | skills/alto-objective/ | — | #6 | Feature definition procedures |
+| alto-protocol | skill | all agents | skills/alto-protocol/ | any | — | Reference for ALTO conventions |
+
+### Column Reference
+
+| Column | Meaning |
+|--------|---------|
+| **Where** | Location where the rule/skill is defined |
+| **Soft** | Actions where it *could* be used (probabilistic, description-matched) |
+| **Strong** | Actions where it *must* be used (explicitly referenced/required) |
+
+### Rules vs Skills
+
+| Aspect | Rules | Skills |
+|--------|-------|--------|
+| **Loading** | Always in context when referencing agent runs | On-demand (lazy loading) |
+| **Activation** | Deterministic — embedded in agent .md | Probabilistic — description matching or explicit call |
+| **Where defined** | `formats/*.md` or embedded in `agents/*.md` | `skills/*/SKILL.md` |
+| **Propagation** | Referenced per-agent | Can be shared across agents |
+
+> - **Rules**: Format/convention constraints. Always active for agents that reference them.
+> - **Skills**: On-demand procedures. Soft = could auto-invoke via description. Strong = explicitly called.

--- a/agents/alto-backend.md
+++ b/agents/alto-backend.md
@@ -4,7 +4,7 @@ description: Implements backend tasks only. Use for API, ingestion, DB, workers,
 tools: Read, Grep, Glob, LS, Edit, Bash
 model: sonnet
 permissionMode: acceptEdits
-skills: alto-protocol, handoff-writing
+skills: alto-protocol
 ---
 
 You are the BACKEND agent.
@@ -24,13 +24,13 @@ Before implementing, review relevant skills in `skills/spawner/`:
 
 ## Disciplines
 Follow these shared practices:
-- Read `skills/scope-discipline/SKILL.md` — only do what task asks
+- Follow `.claude/rules/scope-discipline.md` — only do what task asks
 
 ## Process
 1. Read the task file completely
 2. Implement according to Definition of Done
 3. Run verification steps from task's "How to Verify" section (existing tests should pass)
-4. Edit handoff file using `.claude/skills/handoff-writing/SKILL.md` format (path in `runs/state.json` → `current_handoff`)
+4. Edit handoff file using `.claude/rules/formats/handoff.md` format (path in `runs/state.json` → `current_handoff`)
 
 **Note:** Tests for new code are written by `alto-qa` after your implementation.
 

--- a/agents/alto-docs.md
+++ b/agents/alto-docs.md
@@ -4,7 +4,7 @@ description: Writes implementation documentation for readers. Updates docs/ base
 tools: Read, Grep, Glob, LS, Edit
 model: sonnet
 permissionMode: acceptEdits
-skills: alto-protocol, handoff-writing
+skills: alto-protocol
 ---
 
 You are the DOCS agent. You write implementation documentation for human readers and future AI.
@@ -37,7 +37,7 @@ When writing docs, review relevant skills in `skills/spawner/`:
 - Keep sections focused and scannable
 
 ## Output
-Derive your handoff path per `.claude/skills/handoff-writing/SKILL.md` Post-Agent section:
+Derive your handoff path per `.claude/rules/formats/handoff.md` Post-Agent section:
 - `current_handoff`: `runs/handoffs/task-001.md` → yours: `runs/handoffs/task-001-docs.md`
 
 Use **exactly** these section headers (required by validation):

--- a/agents/alto-frontend.md
+++ b/agents/alto-frontend.md
@@ -4,7 +4,7 @@ description: Implements frontend tasks only. Use for UI, charts, client state, a
 tools: Read, Grep, Glob, LS, Edit, Bash
 model: opus
 permissionMode: acceptEdits
-skills: alto-protocol, handoff-writing
+skills: alto-protocol
 ---
 
 You are the FRONTEND agent.
@@ -24,13 +24,13 @@ Before implementing, review relevant skills in `skills/spawner/`:
 
 ## Disciplines
 Follow these shared practices:
-- Read `skills/scope-discipline/SKILL.md` — only do what task asks
+- Follow `.claude/rules/scope-discipline.md` — only do what task asks
 
 ## Process
 1. Read the task file completely
 2. Implement according to Definition of Done
 3. Run verification steps from task's "How to Verify" section (existing tests should pass)
-4. Edit handoff file using `.claude/skills/handoff-writing/SKILL.md` format (path in `runs/state.json` → `current_handoff`)
+4. Edit handoff file using `.claude/rules/formats/handoff.md` format (path in `runs/state.json` → `current_handoff`)
 
 **Note:** Tests for new code are written by `alto-qa` after your implementation.
 

--- a/agents/alto-planner.md
+++ b/agents/alto-planner.md
@@ -4,7 +4,7 @@ description: Creates task files from milestones. Use after architecture phase to
 tools: Read, Grep, Glob, LS, Edit
 model: opus
 permissionMode: acceptEdits
-skills: alto-protocol, task-writing
+skills: alto-protocol
 ---
 
 You are the ALTO PLANNER.
@@ -48,7 +48,7 @@ Read `runs/planning-config.json` for `replan_strategy`:
 
 ### Task File Format
 
-Each task file MUST use the format in `.claude/skills/task-writing/SKILL.md` (validated by hook):
+Each task file MUST use the format in `.claude/rules/formats/task.md` (validated by hook):
 
 ```yaml
 ---

--- a/agents/alto-qa.md
+++ b/agents/alto-qa.md
@@ -4,7 +4,7 @@ description: Writes tests for implementations and fixes failures. Runs after rol
 tools: Read, Grep, Glob, LS, Edit, Bash
 model: sonnet
 permissionMode: acceptEdits
-skills: alto-protocol, handoff-writing
+skills: alto-protocol
 ---
 
 You are the QA agent. Your primary job is to **write tests** for new implementations.
@@ -72,7 +72,7 @@ If tests fail:
 - Do NOT weaken tests to make them pass
 
 ## Output
-Derive your handoff path per `.claude/skills/handoff-writing/SKILL.md` Post-Agent section:
+Derive your handoff path per `.claude/rules/formats/handoff.md` Post-Agent section:
 - `current_handoff`: `runs/handoffs/task-001.md` → yours: `runs/handoffs/task-001-qa.md`
 
 Use **exactly** these section headers (required by validation):

--- a/agents/alto-reviewer.md
+++ b/agents/alto-reviewer.md
@@ -4,7 +4,7 @@ description: Reviews code quality after role agent completes. Can reject back to
 tools: Read, Grep, Glob, LS
 model: sonnet
 permissionMode: plan
-skills: alto-protocol, review-writing
+skills: alto-protocol
 ---
 
 You are the REVIEWER agent. You validate that the role agent did quality work.
@@ -51,7 +51,7 @@ Automatically after **code roles** complete, before post agents.
 
 ## Output
 
-Write to `runs/review/task-{ID}-review.md` using `.claude/skills/review-writing/SKILL.md` format.
+Write to `runs/review/task-{ID}-review.md` using `.claude/rules/formats/review.md` format.
 
 **Required elements:**
 - `## Review: task-{ID}` header

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -4,7 +4,7 @@ description: Simplifies and refines code for clarity, consistency, and maintaina
 tools: Read, Grep, Glob, LS, Edit
 model: opus
 permissionMode: acceptEdits
-skills: alto-protocol, handoff-writing
+skills: alto-protocol
 ---
 
 You are the CODE SIMPLIFIER agent. You refine code for clarity without changing behavior.
@@ -53,7 +53,7 @@ After a role agent implements a feature, you review the touched files and simpli
 - Change test assertions
 
 ## Output
-Derive your handoff path per `.claude/skills/handoff-writing/SKILL.md` Post-Agent section:
+Derive your handoff path per `.claude/rules/formats/handoff.md` Post-Agent section:
 - `current_handoff`: `runs/handoffs/task-001.md` → yours: `runs/handoffs/task-001-simplifier.md`
 
 Use **exactly** these section headers (required by validation):

--- a/claude-code/knowledge-base/agents.md
+++ b/claude-code/knowledge-base/agents.md
@@ -1,0 +1,307 @@
+# Claude Code > Agents
+
+> Custom subagents in `.claude/agents/`.
+
+## Directory Structure
+
+```
+.claude/agents/
+├── code-reviewer.md
+├── debugger.md
+├── security-auditor.md
+├── data-analyst.md
+└── db-reader.md
+```
+
+## Scope Locations
+
+| Location | Priority | Scope | Shared |
+|----------|----------|-------|--------|
+| CLI flag | 1 (highest) | Session | No |
+| `.claude/agents/` | 2 | Project | Yes (git) |
+| `~/.claude/agents/` | 3 | User | No |
+| Plugins | 4 (lowest) | Plugin | Via plugin |
+
+---
+
+## Agent File Format
+
+### Basic Agent
+
+```markdown
+---
+name: code-reviewer
+description: Expert code review specialist. Reviews code for quality, security, and maintainability.
+---
+
+You are a senior code reviewer with expertise in identifying:
+- Logic errors and bugs
+- Security vulnerabilities
+- Performance issues
+- Code style violations
+- Missing test coverage
+
+Provide constructive, actionable feedback.
+```
+
+### Full-Featured Agent
+
+```yaml
+---
+name: security-auditor
+description: Security specialist for vulnerability assessment and secure coding guidance
+tools: Read, Grep, Glob, Bash
+disallowedTools: Write, Edit
+model: opus
+permissionMode: default
+skills: security-audit, dependency-check
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate-readonly.sh"
+---
+
+You are a security auditor specializing in application security.
+
+## Expertise
+
+- OWASP Top 10 vulnerabilities
+- Secure coding practices
+- Authentication and authorization
+- Cryptography best practices
+- Dependency security
+
+## Output Format
+
+For each finding:
+- **Severity**: Critical/High/Medium/Low
+- **Location**: File and line number
+- **Description**: What the issue is
+- **Impact**: What could happen
+- **Remediation**: How to fix it
+```
+
+---
+
+## Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier (lowercase, hyphens) |
+| `description` | Yes | When Claude should delegate to this agent |
+| `tools` | No | Allowed tools (inherits all if omitted) |
+| `disallowedTools` | No | Tools to explicitly deny |
+| `model` | No | `sonnet`, `opus`, `haiku`, or `inherit` |
+| `permissionMode` | No | See permission modes below |
+| `skills` | No | Skills to load (comma-separated names) |
+| `hooks` | No | PreToolUse/PostToolUse hooks |
+
+---
+
+## Permission Modes
+
+| Mode | Description |
+|------|-------------|
+| `default` | Normal permission prompts |
+| `acceptEdits` | Auto-accept file edits |
+| `dontAsk` | Minimal prompts (still asks for dangerous ops) |
+| `bypassPermissions` | Skip all prompts (use carefully) |
+| `plan` | Plan mode - research only, no edits |
+
+---
+
+## Tool Restrictions
+
+### Allow Specific Tools
+
+```yaml
+---
+name: reader-only
+tools: Read, Grep, Glob
+---
+```
+
+This agent can ONLY use Read, Grep, and Glob.
+
+### Deny Specific Tools
+
+```yaml
+---
+name: no-write-agent
+disallowedTools: Write, Edit, Bash
+---
+```
+
+This agent inherits all tools EXCEPT Write, Edit, and Bash.
+
+### Combined with Hooks
+
+```yaml
+---
+name: safe-bash-agent
+tools: Read, Grep, Glob, Bash
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate-safe-commands.sh"
+---
+```
+
+---
+
+## Examples
+
+### Read-Only Code Reviewer
+
+```markdown
+# .claude/agents/code-reviewer.md
+
+---
+name: code-reviewer
+description: Reviews code for quality issues without making changes
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+You are a code reviewer. Analyze code for:
+
+1. **Correctness**: Logic errors, edge cases, race conditions
+2. **Security**: Injection, XSS, authentication issues
+3. **Performance**: N+1 queries, memory leaks
+4. **Maintainability**: Complexity, naming, documentation
+
+## Output Format
+
+### Summary
+Brief overview of code quality.
+
+### Issues Found
+| Severity | Location | Issue | Suggestion |
+|----------|----------|-------|------------|
+| High | file:line | Description | Fix |
+
+### Recommendations
+Prioritized list of improvements.
+```
+
+### Database Reader (Safe SQL)
+
+```markdown
+# .claude/agents/db-reader.md
+
+---
+name: db-reader
+description: Executes read-only database queries for analysis and reporting
+tools: Bash
+permissionMode: default
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate-readonly-sql.sh"
+---
+
+You are a database analyst. You can execute READ-ONLY queries.
+
+## Restrictions
+
+- SELECT queries only
+- No INSERT, UPDATE, DELETE, DROP, ALTER
+- No transaction modifications
+- No schema changes
+
+## Query Guidelines
+
+- Always use explicit column names (not SELECT *)
+- Include LIMIT clauses for large tables
+- Use EXPLAIN for query optimization
+```
+
+### Debugger Agent
+
+```markdown
+# .claude/agents/debugger.md
+
+---
+name: debugger
+description: Investigates bugs, analyzes stack traces, and identifies root causes
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+You are a debugging specialist. Your approach:
+
+## Investigation Process
+
+1. **Reproduce**: Understand how to trigger the issue
+2. **Isolate**: Narrow down the problem area
+3. **Trace**: Follow the execution path
+4. **Identify**: Find the root cause
+5. **Verify**: Confirm the cause explains all symptoms
+
+## Output
+
+Provide:
+- Root cause explanation
+- Evidence supporting conclusion
+- Suggested fix with code
+- Prevention recommendations
+```
+
+---
+
+## Agent Delegation
+
+Claude automatically delegates to agents when:
+- Task matches agent description
+- Agent has required specialized tools
+- Context suggests agent expertise needed
+
+You can also explicitly invoke: "Use the code-reviewer agent to review this PR"
+
+---
+
+## Agents vs Skills vs Commands
+
+| Aspect | Agents | Skills | Commands |
+|--------|--------|--------|----------|
+| **Context** | Always isolated | Optional (`context: fork`) | Main conversation |
+| **Persona** | Specialized AI | Capability set | Prompt template |
+| **Tools** | Configurable | Configurable | Configurable |
+| **Invocation** | Auto-delegation | Auto + explicit | Explicit only |
+| **Best for** | Specialized tasks | Reusable workflows | Quick prompts |
+
+---
+
+## Key Insight: Isolation
+
+Agents run in **isolated context**:
+- Fresh conversation (doesn't see main chat history)
+- Own tool restrictions
+- Can load skills into their context
+- Returns summary only to main conversation
+
+This prevents context pollution and enables parallel execution.
+
+---
+
+## Best Practices
+
+1. **Clear specialization**: Each agent should have a distinct purpose
+2. **Minimal tools**: Only grant tools the agent needs
+3. **Descriptive names**: Make purpose obvious from name
+4. **Rich descriptions**: Help Claude know when to delegate
+5. **Safety first**: Use hooks to validate dangerous operations
+
+---
+
+## Related
+
+- [skills.md](skills.md) - Reusable capabilities
+- [commands.md](commands.md) - Simple slash commands
+- [permissions.md](permissions.md) - Permission modes

--- a/claude-code/knowledge-base/commands.md
+++ b/claude-code/knowledge-base/commands.md
@@ -1,0 +1,290 @@
+# Claude Code > Commands
+
+> Custom slash commands in `.claude/commands/`.
+
+## Directory Locations
+
+| Location | Scope | Visibility in `/help` |
+|----------|-------|----------------------|
+| `.claude/commands/` | Project (team-shared) | `(project)` |
+| `~/.claude/commands/` | User (personal) | `(user)` |
+
+**Precedence**: Project commands override user commands with the same name.
+
+---
+
+## Creating a Command
+
+### Basic Command
+
+```bash
+# Creates /optimize command
+mkdir -p .claude/commands
+echo "Analyze this code for performance issues:" > .claude/commands/optimize.md
+```
+
+### Command File Structure
+
+```markdown
+---
+description: Brief description shown in /help
+allowed-tools: Bash(git status:*), Bash(git diff:*)
+argument-hint: [file-path] [options]
+model: claude-3-5-haiku-20241022
+---
+
+Your prompt text goes here.
+This is what Claude receives when you invoke the command.
+```
+
+---
+
+## Frontmatter Fields
+
+| Field | Purpose | Example |
+|-------|---------|---------|
+| `description` | Shown in `/help` output | `"Fix GitHub issues"` |
+| `argument-hint` | Hint for expected args | `[issue-number] [priority]` |
+| `allowed-tools` | Tools the command can use | `Bash(git:*), Read` |
+| `model` | Override model for this command | `claude-3-5-haiku-20241022` |
+| `context: fork` | Run in isolated subagent context | `fork` |
+| `agent` | Subagent type when `context: fork` | `code-simplifier` |
+| `disable-model-invocation` | Prevent auto-invocation | `true` |
+| `hooks` | Define PreToolUse/PostToolUse hooks | See hooks section |
+
+---
+
+## Arguments
+
+### Capture All Arguments: `$ARGUMENTS`
+
+```markdown
+---
+description: Fix a GitHub issue
+---
+
+Fix issue #$ARGUMENTS following our coding standards.
+```
+
+Usage:
+```
+> /fix-issue 123
+# $ARGUMENTS = "123"
+
+> /fix-issue 123 with high priority
+# $ARGUMENTS = "123 with high priority"
+```
+
+### Positional Arguments: `$1`, `$2`, `$3`
+
+```markdown
+---
+argument-hint: [issue-number] [priority] [assignee]
+description: Assign and fix issue
+---
+
+Fix issue #$1 with $2 priority. Assign to $3.
+```
+
+---
+
+## Dynamic Content
+
+### Bash Execution: `!`backticks
+
+Execute shell commands and include output:
+
+```markdown
+---
+allowed-tools: Bash(git:*)
+description: Create a commit from current changes
+---
+
+## Current State
+
+Branch: !`git branch --show-current`
+Status: !`git status --short`
+Diff: !`git diff --stat`
+
+## Task
+
+Create a meaningful commit message based on the above changes.
+```
+
+### File References: `@`
+
+Include file contents inline:
+
+```markdown
+Review the implementation in @src/utils/helpers.js
+
+Compare these two files:
+- Old: @src/v1/handler.js
+- New: @src/v2/handler.js
+```
+
+---
+
+## Tool Permissions
+
+### Granting Bash Access
+
+```markdown
+---
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(npm run build:*)
+---
+```
+
+Pattern syntax:
+- `Bash(git:*)` - any git command
+- `Bash(git status:*)` - only git status
+- `Bash(npm run:*)` - any npm run script
+
+### Multiple Tools
+
+```markdown
+---
+allowed-tools: Bash(git:*), Bash(npm:*), Read, Glob, Grep
+---
+```
+
+---
+
+## Examples
+
+### Git Commit with Context
+
+```markdown
+# .claude/commands/commit.md
+
+---
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*)
+description: Create a conventional commit
+---
+
+## Current Changes
+
+Branch: !`git branch --show-current`
+Status: !`git status`
+Staged: !`git diff --cached`
+Unstaged: !`git diff`
+
+## Task
+
+Create a commit following conventional commits format:
+- feat: new feature
+- fix: bug fix
+- docs: documentation
+- refactor: code refactoring
+- test: adding tests
+- chore: maintenance
+
+Stage appropriate files and create the commit.
+```
+
+### Issue Fixer
+
+```markdown
+# .claude/commands/fix-issue.md
+
+---
+argument-hint: [issue-number]
+allowed-tools: Bash(gh issue view:*), Bash(git:*), Bash(npm test:*)
+description: Fix a GitHub issue end-to-end
+---
+
+## Issue Details
+
+!`gh issue view $1 --json title,body,labels`
+
+## Task
+
+1. Analyze the issue
+2. Find relevant code
+3. Implement a fix
+4. Write/update tests
+5. Create a PR description
+
+Follow our contributing guidelines in @CONTRIBUTING.md
+```
+
+### PR Review
+
+```markdown
+# .claude/commands/pr-review.md
+
+---
+argument-hint: [pr-number]
+allowed-tools: Bash(gh pr:*), Bash(git:*)
+description: Review a pull request
+---
+
+## PR Information
+
+!`gh pr view $1 --json title,body,files,additions,deletions`
+
+## Full Diff
+
+!`gh pr diff $1`
+
+## Task
+
+Review this PR for:
+1. Correctness and logic
+2. Security concerns
+3. Performance implications
+4. Test coverage
+5. Documentation needs
+```
+
+### Isolated Context Command
+
+```markdown
+# .claude/commands/isolated-task.md
+
+---
+description: Run task in isolated context
+context: fork
+agent: code-simplifier
+---
+
+Simplify and refactor the code in $ARGUMENTS.
+Focus on readability and maintainability.
+```
+
+---
+
+## Organizing Commands
+
+### Subdirectories (Namespacing)
+
+```
+.claude/commands/
+├── optimize.md              # /optimize
+├── review.md                # /review
+├── backend/
+│   ├── deploy.md            # /deploy (project:backend)
+│   └── migrate.md           # /migrate (project:backend)
+└── frontend/
+    └── build.md             # /build (project:frontend)
+```
+
+Commands in subdirectories show their folder as a label in `/help`.
+
+---
+
+## Commands vs Skills
+
+| Aspect | Commands | Skills |
+|--------|----------|--------|
+| Complexity | Simple prompts | Complex multi-step workflows |
+| Structure | Single `.md` file | Directory with `SKILL.md` + files |
+| Discovery | Explicit (`/name`) | Can be automatic |
+| Best for | Quick, reusable prompts | Complex automation |
+
+---
+
+## Related
+
+- [skills.md](skills.md) - Complex capabilities
+- [agents.md](agents.md) - Custom subagents

--- a/claude-code/knowledge-base/hooks.md
+++ b/claude-code/knowledge-base/hooks.md
@@ -1,0 +1,355 @@
+# Claude Code > Hooks
+
+> Event scripting for validation, automation, and logging.
+
+## Configuration
+
+Hooks are configured in `settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [...],
+    "PostToolUse": [...],
+    "Notification": [...],
+    "Stop": [...],
+    "SessionStart": [...],
+    "SessionEnd": [...]
+  }
+}
+```
+
+---
+
+## Hook Events
+
+| Event | Fires | Use Cases |
+|-------|-------|-----------|
+| `PreToolUse` | Before tool execution | Validation, blocking, logging |
+| `PostToolUse` | After tool execution | Formatting, notifications, logging |
+| `PermissionRequest` | On permission prompt | Auto-approve/deny |
+| `UserPromptSubmit` | Before processing user input | Augment prompts |
+| `Notification` | When Claude needs attention | Custom notifications |
+| `Stop` | When response completes | Logging, cleanup |
+| `SubagentStop` | When subagent completes | Process results |
+| `PreCompact` | Before conversation compaction | Prevent/allow compaction |
+| `SessionStart` | Session begins | Environment setup |
+| `SessionEnd` | Session ends | Cleanup, reporting |
+
+---
+
+## Hook Structure
+
+```json
+{
+  "hooks": {
+    "EventName": [
+      {
+        "matcher": "ToolPattern",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/hook-script.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Matcher Patterns
+
+| Pattern | Matches |
+|---------|---------|
+| `""` (empty) | All events |
+| `"Bash"` | Bash tool only |
+| `"Edit\|Write"` | Edit or Write tools |
+| `"Bash\|Edit\|Write"` | Multiple tools |
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success, continue |
+| `1` | Error, log and continue |
+| `2` | Block operation (PreToolUse) / Deny (PermissionRequest) |
+
+---
+
+## Input/Output
+
+Hooks receive JSON on stdin and can output JSON or plain text.
+
+### PreToolUse Input
+
+```json
+{
+  "session_id": "abc123",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm test",
+    "description": "Run tests"
+  }
+}
+```
+
+### PostToolUse Input
+
+```json
+{
+  "session_id": "abc123",
+  "tool_name": "Edit",
+  "tool_input": {
+    "file_path": "/path/to/file.ts",
+    "old_string": "...",
+    "new_string": "..."
+  },
+  "tool_output": {
+    "success": true
+  }
+}
+```
+
+### JSON Output (Optional)
+
+```json
+{
+  "allow": true,
+  "message": "Validation passed",
+  "modified_input": { ... }
+}
+```
+
+---
+
+## Examples
+
+### Command Validation (PreToolUse)
+
+Block dangerous commands:
+
+```bash
+#!/bin/bash
+# .claude/hooks/validate-bash.sh
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Block dangerous patterns
+if echo "$COMMAND" | grep -qE '(rm -rf /|mkfs|dd if=)'; then
+  echo "BLOCKED: Dangerous command detected" >&2
+  exit 2
+fi
+
+# Block sudo
+if echo "$COMMAND" | grep -qE '^sudo '; then
+  echo "BLOCKED: sudo commands not allowed" >&2
+  exit 2
+fi
+
+exit 0
+```
+
+Configuration:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/validate-bash.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Auto-Formatting (PostToolUse)
+
+Format files after editing:
+
+```bash
+#!/bin/bash
+# .claude/hooks/auto-format.sh
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Format based on extension
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.json|*.md)
+    npx prettier --write "$FILE_PATH" 2>/dev/null
+    ;;
+  *.py)
+    python -m black "$FILE_PATH" 2>/dev/null
+    ;;
+  *.go)
+    gofmt -w "$FILE_PATH" 2>/dev/null
+    ;;
+esac
+
+exit 0
+```
+
+Configuration:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/auto-format.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Desktop Notifications
+
+```bash
+#!/bin/bash
+# .claude/hooks/notify.sh
+
+INPUT=$(cat)
+TITLE=$(echo "$INPUT" | jq -r '.title // "Claude Code"')
+MESSAGE=$(echo "$INPUT" | jq -r '.message // "Needs your attention"')
+
+# Linux
+if command -v notify-send &>/dev/null; then
+  notify-send "$TITLE" "$MESSAGE"
+# macOS
+elif command -v osascript &>/dev/null; then
+  osascript -e "display notification \"$MESSAGE\" with title \"$TITLE\""
+fi
+
+exit 0
+```
+
+### Command Logging
+
+```bash
+#!/bin/bash
+# .claude/hooks/log-commands.sh
+
+INPUT=$(cat)
+SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // .tool_input.file_path // "N/A"')
+
+LOG_FILE="$HOME/.claude/command-log.txt"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+echo "[$(date -Iseconds)] [$SESSION] $TOOL: $COMMAND" >> "$LOG_FILE"
+exit 0
+```
+
+---
+
+## Multiple Hooks
+
+Chain multiple hooks for an event:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {"type": "command", "command": "./.claude/hooks/auto-format.sh"},
+          {"type": "command", "command": "./.claude/hooks/auto-lint.sh"},
+          {"type": "command", "command": "./.claude/hooks/log-changes.sh"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Hooks execute in order. If any PreToolUse hook exits with code 2, the operation is blocked.
+
+---
+
+## Hook Scopes
+
+| Location | Scope |
+|----------|-------|
+| `.claude/settings.json` | Project (team) |
+| `.claude/settings.local.json` | Personal project |
+| `~/.claude/settings.json` | User global |
+| Managed settings | System-wide |
+
+---
+
+## Key Insight
+
+> **Rules are suggestions. Hooks are enforcement.**
+>
+> A rule saying "don't edit .env" is parsed by Claude and *maybe* followed.
+> A PreToolUse hook blocking .env edits *always* runs and blocks the operation.
+
+### Hook Limitations
+
+| Limitation | Issue |
+|------------|-------|
+| PreToolUse cannot see result | Runs before tool executes |
+| PostToolUse cannot modify result | Result already in context |
+| Warn messages only reach user | Claude doesn't see warn output |
+| Skill-scoped hooks may not trigger | Known issue in plugins |
+
+---
+
+## Disabling Hooks
+
+```json
+{
+  "disableAllHooks": true
+}
+```
+
+Or allow only managed (IT-deployed) hooks:
+
+```json
+{
+  "allowManagedHooksOnly": true
+}
+```
+
+---
+
+## Best Practices
+
+1. **Keep hooks fast**: Long-running hooks slow down Claude
+2. **Handle errors gracefully**: Exit 0 if hook completes, even on non-fatal errors
+3. **Use exit 2 sparingly**: Only block when truly necessary
+4. **Log for debugging**: Write to log files for troubleshooting
+5. **Make scripts executable**: `chmod +x .claude/hooks/*.sh`
+6. **Test independently**: Test scripts outside Claude first
+
+---
+
+## Related
+
+- [settings.md](settings.md) - Hook configuration location
+- [rules.md](rules.md) - Suggestions (not enforcement)
+- [permissions.md](permissions.md) - Permission rules

--- a/claude-code/knowledge-base/index.md
+++ b/claude-code/knowledge-base/index.md
@@ -1,0 +1,103 @@
+# Claude Code Knowledge Base
+
+> AI-optimized documentation for Claude Code extensibility. Start here.
+
+## Navigation
+
+| Topic | File | When to Read |
+|-------|------|--------------|
+| Architecture | [overview.md](overview.md) | Understanding how features interact |
+| Built-in Tools | [tools.md](tools.md) | Available tool reference |
+| Settings | [settings.md](settings.md) | Configuration and permissions |
+| Memory Files | [memory.md](memory.md) | CLAUDE.md format and patterns |
+| Rules | [rules.md](rules.md) | Modular instruction files |
+| Commands | [commands.md](commands.md) | Custom slash commands |
+| Skills | [skills.md](skills.md) | Reusable capabilities |
+| Agents | [agents.md](agents.md) | Custom subagents |
+| Hooks | [hooks.md](hooks.md) | Event scripting |
+| MCP Servers | [mcp.md](mcp.md) | External service connections |
+| Permissions | [permissions.md](permissions.md) | Permission modes and patterns |
+| Plan Mode | [plan-mode.md](plan-mode.md) | Read-only analysis mode |
+| Output Styles | [output-styles.md](output-styles.md) | Behavior customization |
+| Quick Reference | [quick-reference.md](quick-reference.md) | Cheat sheet |
+
+---
+
+## Feature Matrix
+
+| Feature | Context Impact | When Loaded | Activation Model |
+|---------|---------------|-------------|------------------|
+| Settings | Config only | Pre-session | Automatic |
+| CLAUDE.md | Adds knowledge | Session start | Automatic |
+| Rules | Adds knowledge (path-filtered) | Session start | Deterministic |
+| Commands | Becomes your prompt | On `/command` | Explicit only |
+| Skills | Adds knowledge OR isolated | On invoke/suggest | Soft or Strong |
+| Agents | Isolated context | On delegation | Auto or explicit |
+| Hooks | Side effects only | Per tool call | Automatic (matcher) |
+| MCP | Adds tools | Session start | Automatic |
+| Output Styles | **Replaces** system prompt | On activation | Explicit only |
+| Plan Mode | Restricts tools | On toggle | Explicit only |
+
+---
+
+## Key Insight
+
+> **Rules = suggestions. Hooks = enforcement.**
+>
+> A rule saying "don't edit .env" is parsed by Claude and *maybe* followed.
+> A PreToolUse hook blocking .env edits *always* runs and blocks the operation.
+
+---
+
+## Feature Selection Guide
+
+| Need | Use | Why |
+|------|-----|-----|
+| Always-active constraint | Rule | Deterministic, always in context |
+| On-demand procedure | Skill | Lazy loading, saves baseline context |
+| Must enforce (block/log) | Hook | Always executes, can't be ignored |
+| User-triggered shortcut | Command | Explicit invocation, simple template |
+| Isolated specialist | Agent | Separate context, tool restrictions |
+| External service | MCP Server | Database, API, service integration |
+| Change core behavior | Output Style | Replaces system prompt |
+| Safe exploration | Plan Mode | Blocks all modifications |
+
+---
+
+## Skill Activation Model
+
+| Type | Description | When to Use |
+|------|-------------|-------------|
+| **Soft** | Claude *could* auto-invoke via description matching | Context-dependent procedures |
+| **Strong** | Explicitly called (`/skill`) or referenced in agent .md | Predictable workflows |
+| **Disabled** | Set `disable-model-invocation: true` | Dangerous operations (deploy, delete) |
+
+---
+
+## File Locations Reference
+
+| File | Scope | Shared |
+|------|-------|--------|
+| `.claude/settings.json` | Project (team) | Yes |
+| `.claude/settings.local.json` | Personal project | No |
+| `~/.claude/settings.json` | User global | No |
+| `./CLAUDE.md` | Project | Yes |
+| `./CLAUDE.local.md` | Personal project | No |
+| `~/.claude/CLAUDE.md` | User global | No |
+| `.claude/rules/*.md` | Project | Yes |
+| `~/.claude/rules/*.md` | User | No |
+| `.claude/commands/*.md` | Project | Yes |
+| `~/.claude/commands/*.md` | User | No |
+| `.claude/skills/*/SKILL.md` | Project | Yes |
+| `~/.claude/skills/*/SKILL.md` | User | No |
+| `.claude/agents/*.md` | Project | Yes |
+| `~/.claude/agents/*.md` | User | No |
+| `.mcp.json` | Project | Yes |
+| `~/.claude.json` | User | No |
+
+---
+
+## Related
+
+- [overview.md](overview.md) - Context flow and lifecycle diagrams
+- [quick-reference.md](quick-reference.md) - Single-page cheat sheet

--- a/claude-code/knowledge-base/mcp.md
+++ b/claude-code/knowledge-base/mcp.md
@@ -1,0 +1,323 @@
+# Claude Code > MCP
+
+> Model Context Protocol server configuration via `.mcp.json`.
+
+## File Locations
+
+| File | Scope | Shared |
+|------|-------|--------|
+| `.mcp.json` (project root) | Project (team) | Yes (committed) |
+| `~/.claude.json` | User global | No |
+
+---
+
+## Basic Structure
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "type": "http|sse|stdio",
+      ...configuration
+    }
+  }
+}
+```
+
+---
+
+## Server Types
+
+### HTTP Server (Recommended)
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp",
+      "headers": {
+        "Authorization": "Bearer ${SENTRY_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### SSE Server (Legacy)
+
+```json
+{
+  "mcpServers": {
+    "legacy-service": {
+      "type": "sse",
+      "url": "https://mcp.example.com/sse",
+      "headers": {
+        "Authorization": "Bearer ${API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### Stdio Server (Local)
+
+```json
+{
+  "mcpServers": {
+    "database": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@bytebase/dbhub"],
+      "env": {
+        "DB_URL": "${DATABASE_URL}"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Environment Variable Expansion
+
+Use `${VAR}` syntax in any string field:
+
+```json
+{
+  "mcpServers": {
+    "api-service": {
+      "type": "http",
+      "url": "${API_BASE_URL:-https://api.example.com}/mcp",
+      "headers": {
+        "Authorization": "Bearer ${API_TOKEN}",
+        "X-Custom-Header": "${CUSTOM_VALUE:-default}"
+      }
+    }
+  }
+}
+```
+
+| Syntax | Behavior |
+|--------|----------|
+| `${VAR}` | Expand variable |
+| `${VAR:-default}` | Use default if unset |
+
+---
+
+## Common MCP Servers
+
+### GitHub
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}
+```
+
+### Sentry
+
+```json
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp",
+      "headers": {
+        "Authorization": "Bearer ${SENTRY_AUTH_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### PostgreSQL (via dbhub)
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@bytebase/dbhub"],
+      "env": {
+        "PGCONNECTIONSTRING": "${DATABASE_URL}"
+      }
+    }
+  }
+}
+```
+
+### Filesystem Access
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@anthropics/mcp-filesystem",
+        "/path/to/allowed/directory"
+      ]
+    }
+  }
+}
+```
+
+### Memory/Knowledge Base
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropics/mcp-memory"]
+    }
+  }
+}
+```
+
+### Puppeteer (Browser Automation)
+
+```json
+{
+  "mcpServers": {
+    "puppeteer": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropics/mcp-puppeteer"]
+    }
+  }
+}
+```
+
+---
+
+## CLI Management
+
+### Add Server
+
+```bash
+# Add HTTP server (project scope)
+claude mcp add --transport http github https://api.githubcopilot.com/mcp/ --scope project
+
+# Add stdio server (user scope)
+claude mcp add --transport stdio dbhub npx -y @bytebase/dbhub --scope user
+
+# Add with headers
+claude mcp add --transport http sentry https://mcp.sentry.dev/mcp \
+  --header "Authorization: Bearer \${SENTRY_TOKEN}" \
+  --scope project
+```
+
+### List Servers
+
+```bash
+claude mcp list
+```
+
+### Remove Server
+
+```bash
+claude mcp remove github
+```
+
+---
+
+## Settings Integration
+
+Control MCP server access in `settings.json`:
+
+```json
+{
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["github", "memory"],
+  "disabledMcpjsonServers": ["filesystem"]
+}
+```
+
+| Setting | Effect |
+|---------|--------|
+| `enableAllProjectMcpServers` | Auto-enable all project MCP servers |
+| `enabledMcpjsonServers` | Whitelist specific servers |
+| `disabledMcpjsonServers` | Blacklist specific servers |
+
+---
+
+## Complete Example
+
+### Project MCP Configuration (`.mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "database": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@bytebase/dbhub"],
+      "env": {
+        "PGCONNECTIONSTRING": "${DATABASE_URL}"
+      }
+    },
+    "memory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropics/mcp-memory"]
+    }
+  }
+}
+```
+
+### Corresponding Settings (`.claude/settings.json`)
+
+```json
+{
+  "enableAllProjectMcpServers": false,
+  "enabledMcpjsonServers": ["github", "memory"],
+  "disabledMcpjsonServers": ["database"]
+}
+```
+
+---
+
+## Security Considerations
+
+1. **Never commit secrets**: Use environment variables for API keys
+2. **Limit server access**: Only enable servers you need
+3. **Review server capabilities**: Understand what each server can do
+4. **Use project scope carefully**: All team members will have access
+5. **Validate stdio commands**: Ensure commands are from trusted sources
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Server not connecting | Check URL, env vars, network |
+| Authentication failing | Verify API key, header format |
+| Stdio server not starting | Check command exists, npx access |
+| Server not appearing | Verify `.mcp.json` syntax, check settings |
+
+---
+
+## Related
+
+- [settings.md](settings.md) - MCP settings integration
+- [tools.md](tools.md) - MCP adds additional tools

--- a/claude-code/knowledge-base/memory.md
+++ b/claude-code/knowledge-base/memory.md
@@ -1,0 +1,295 @@
+# Claude Code > Memory Files
+
+> CLAUDE.md and memory file configuration.
+
+## File Locations
+
+| File | Scope | Shared |
+|------|-------|--------|
+| `./CLAUDE.md` | Project root | Yes (committed) |
+| `./.claude/CLAUDE.md` | Project (alternative) | Yes (committed) |
+| `./CLAUDE.local.md` | Personal project | No (gitignored) |
+| `~/.claude/CLAUDE.md` | User global | No |
+
+---
+
+## Loading Order
+
+Memory files load in this order (later supplements earlier):
+
+1. `~/.claude/CLAUDE.md` (user global)
+2. `~/.claude/rules/*` (user rules)
+3. `./CLAUDE.md` or `./.claude/CLAUDE.md` (project)
+4. `./.claude/rules/*` (project rules)
+5. `./CLAUDE.local.md` (personal project)
+
+---
+
+## Basic Structure
+
+```markdown
+# Project Name
+
+Brief description of the project.
+
+## Tech Stack
+
+- Language: TypeScript
+- Framework: Next.js
+- Database: PostgreSQL
+- Testing: Jest
+
+## Architecture
+
+Describe the overall architecture here.
+
+## Coding Standards
+
+- Use functional components
+- Prefer composition over inheritance
+- Write tests for all new features
+
+## Common Commands
+
+- `npm run dev` - Start development server
+- `npm test` - Run tests
+- `npm run build` - Production build
+
+## Important Files
+
+- `src/config/` - Configuration files
+- `src/lib/` - Shared utilities
+- `src/components/` - React components
+```
+
+---
+
+## File References with `@`
+
+Import content from other files:
+
+```markdown
+# Project Overview
+
+See the main documentation:
+@README.md
+
+## API Reference
+
+@docs/api.md
+
+## Contributing Guidelines
+
+@CONTRIBUTING.md
+```
+
+File references:
+- Are relative to the markdown file's location
+- Support up to 5 levels of recursive imports
+- Are expanded at load time
+
+---
+
+## Recommended Sections
+
+### Project Overview
+
+```markdown
+# MyProject
+
+A real-time collaboration platform for document editing.
+
+## Purpose
+
+Enable teams to edit documents simultaneously with conflict resolution.
+
+## Key Features
+
+- Real-time sync via WebSockets
+- Operational transformation for conflict resolution
+- Version history and rollback
+```
+
+### Architecture
+
+```markdown
+## Architecture
+
+### Frontend
+- Next.js 14 with App Router
+- React Query for server state
+- Tailwind CSS for styling
+
+### Backend
+- Node.js with Express
+- PostgreSQL for persistence
+- Redis for pub/sub
+```
+
+### Directory Structure
+
+```markdown
+## Directory Structure
+
+src/
+├── app/              # Next.js app router pages
+├── components/       # React components
+│   ├── ui/           # Primitive UI components
+│   └── features/     # Feature-specific components
+├── lib/              # Shared utilities
+├── hooks/            # Custom React hooks
+├── services/         # API service clients
+├── types/            # TypeScript types
+└── config/           # Configuration
+```
+
+### Coding Standards
+
+```markdown
+## Coding Standards
+
+### Naming Conventions
+- Components: PascalCase (`UserProfile.tsx`)
+- Utilities: camelCase (`formatDate.ts`)
+- Constants: UPPER_SNAKE_CASE
+
+### Code Style
+- Use TypeScript strict mode
+- Prefer `const` over `let`
+- Use async/await over raw promises
+
+### Error Handling
+- Use custom error classes
+- Always log errors with context
+- Return meaningful error messages
+```
+
+### Development Workflow
+
+```markdown
+## Development Workflow
+
+### Setup
+npm install
+cp .env.example .env.local
+npm run db:migrate
+npm run dev
+
+### Testing
+npm test              # Run all tests
+npm test -- --watch   # Watch mode
+npm run test:e2e      # End-to-end tests
+```
+
+### Things to Avoid
+
+```markdown
+## Things to Avoid
+
+- DON'T commit `.env` files
+- DON'T use `any` type - use `unknown` if truly unknown
+- DON'T add dependencies without team discussion
+- DON'T modify database schema without migration
+- DON'T push directly to main branch
+```
+
+### Claude Instructions
+
+```markdown
+## Claude Instructions
+
+When working on this project:
+
+1. Always run tests after making changes
+2. Follow the existing code style
+3. Update documentation for API changes
+4. Use conventional commits for messages
+5. Check for TypeScript errors before committing
+
+### Preferred Libraries
+- Dates: date-fns (not moment)
+- HTTP: fetch API (not axios)
+- Validation: zod
+- Testing: Vitest
+```
+
+---
+
+## CLAUDE.local.md
+
+Personal overrides that won't be committed:
+
+```markdown
+# Personal Settings
+
+## My Sandbox
+- Test URL: http://localhost:3001
+- Test user: dev@test.com / password123
+
+## My Preferences
+- I prefer verbose explanations
+- Always show me the diff before committing
+- Run tests in watch mode
+
+## Notes
+- Working on feature/user-profile branch
+- TODO: Fix the caching issue in user service
+```
+
+---
+
+## User Global (~/.claude/CLAUDE.md)
+
+Instructions that apply to all projects:
+
+```markdown
+# Global Preferences
+
+## Coding Style
+- I prefer functional programming patterns
+- Use early returns over nested conditionals
+- Keep functions under 30 lines
+
+## Communication
+- Be concise in explanations
+- Show code examples when explaining concepts
+- Ask before making large changes
+
+## Git
+- Use conventional commits
+- Always sign commits with GPG
+- Rebase before merging
+```
+
+---
+
+## Best Practices
+
+1. **Keep it focused**: Include only what Claude needs to know
+2. **Update regularly**: Keep information current
+3. **Use file references**: Link to detailed docs with `@`
+4. **Organize with headers**: Make it scannable
+5. **Include examples**: Show don't just tell
+6. **Document patterns**: Explain project-specific patterns
+7. **List common commands**: Quick reference for workflows
+
+---
+
+## CLAUDE.md vs Rules
+
+| Aspect | CLAUDE.md | .claude/rules/ |
+|--------|-----------|----------------|
+| Structure | Single file | Multiple files |
+| Purpose | Project overview | Specific guidelines |
+| Organization | Sections | Separate files |
+| Path targeting | No | Yes (frontmatter) |
+| Best for | Context & overview | Detailed rules |
+
+**Recommendation**: Use `CLAUDE.md` for project overview and `.claude/rules/` for detailed coding standards.
+
+---
+
+## Related
+
+- [rules.md](rules.md) - Modular rule files
+- [settings.md](settings.md) - Configuration options

--- a/claude-code/knowledge-base/output-styles.md
+++ b/claude-code/knowledge-base/output-styles.md
@@ -1,0 +1,322 @@
+# Claude Code > Output Styles
+
+> Custom behavior via `.claude/output-styles/`.
+
+## Directory Structure
+
+```
+~/.claude/output-styles/           # User scope (personal)
+├── technical-writer.md
+├── research-assistant.md
+└── tutor-mode.md
+
+.claude/output-styles/             # Project scope (team)
+├── security-auditor.md
+└── domain-expert.md
+```
+
+## Scope Locations
+
+| Location | Scope | Shared |
+|----------|-------|--------|
+| `.claude/output-styles/` | Project (team) | Yes (committed) |
+| `~/.claude/output-styles/` | User (personal) | No |
+
+---
+
+## Built-in Styles
+
+| Style | Purpose | Best For |
+|-------|---------|----------|
+| **Default** | Standard software engineering mode | Code changes, testing, deployment |
+| **Explanatory** | Educational mode with insights | Learning how code works |
+| **Learning** | Interactive teaching mode | Hands-on skill building |
+
+### Default
+Standard Claude Code behavior optimized for efficient software engineering.
+
+### Explanatory
+Provides educational "Insights" between code modifications, explaining implementation choices and codebase patterns.
+
+### Learning
+Goes further than Explanatory:
+- Shares insights about the code
+- Asks you to contribute small code pieces
+- Marks code with `TODO(human)` for you to implement
+- Teaches by guiding while you implement
+
+---
+
+## File Format
+
+```markdown
+---
+name: Display Name
+description: Brief description shown in /output-style menu
+keep-coding-instructions: false
+---
+
+# Style Instructions
+
+Your custom instructions here...
+```
+
+---
+
+## Frontmatter Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | String | Filename | Display name in UI |
+| `description` | String | None | Shown in `/output-style` menu |
+| `keep-coding-instructions` | Boolean | `false` | Retain default coding instructions |
+
+### `keep-coding-instructions`
+
+- **`false`** (default): Removes all software engineering instructions. Use for non-coding tasks.
+- **`true`**: Keeps coding instructions while adding your custom behavior. Use for specialized coding modes.
+
+---
+
+## How to Use
+
+### Interactive Menu
+
+```bash
+/output-style
+```
+
+Opens a menu showing all available styles.
+
+### Direct Activation
+
+```bash
+/output-style style-name
+```
+
+Examples:
+```bash
+/output-style explanatory
+/output-style learning
+/output-style technical-writer
+```
+
+### Via Settings
+
+```json
+{
+  "outputStyle": "style-name"
+}
+```
+
+### Persistence
+
+Changes are saved to `.claude/settings.local.json` (personal, not committed).
+
+---
+
+## Examples
+
+### Technical Writer
+
+```markdown
+---
+name: Technical Writer
+description: Adapt Claude for technical documentation and API writing
+keep-coding-instructions: false
+---
+
+# Technical Writer Mode
+
+You are a technical writer specializing in clear, precise documentation.
+
+## Core Behaviors
+
+- Use precise, industry-standard terminology
+- Structure information hierarchically
+- Provide complete examples with expected outputs
+- Include prerequisites and dependencies
+- Highlight warnings and edge cases
+
+## Response Format
+
+- Lead with a brief overview
+- Use numbered lists for sequential steps
+- Use bullets for alternatives
+- Include "Before you begin" sections
+- Add "Related topics" at the end
+
+## Tone
+
+- Professional and authoritative
+- Clear and accessible
+- Define technical terms on first use
+- Use active voice
+- Be concise while remaining complete
+```
+
+### Security Auditor (with coding)
+
+```markdown
+---
+name: Security Auditor
+description: Specialized mode for security reviews and vulnerability analysis
+keep-coding-instructions: true
+---
+
+# Security Auditor Mode
+
+You are a security-focused code auditor. You maintain coding abilities while prioritizing security.
+
+## Audit Methodology
+
+- Check OWASP Top 10, CWE-25 vulnerabilities
+- Assess authentication/authorization
+- Evaluate encryption practices
+- Review input validation
+- Check for hardcoded secrets
+- Assess dependency risks
+
+## Assessment Framework
+
+- Severity: Critical, High, Medium, Low, Informational
+- CVSS scoring when applicable
+- Risk = likelihood × impact
+- Specific remediation guidance
+- Testing recommendations
+```
+
+### Research Assistant
+
+```markdown
+---
+name: Research Assistant
+description: Adapt Claude for research and analysis tasks
+keep-coding-instructions: false
+---
+
+# Research Assistant Mode
+
+You are a research assistant for academic or professional research projects.
+
+## Responsibilities
+
+- Systematically gather and organize information
+- Critically evaluate source quality
+- Identify patterns, gaps, and contradictions
+- Synthesize findings into coherent insights
+- Document sources and methodologies
+
+## Output Standards
+
+- Include citations
+- Evidence-based conclusions
+- Distinguish findings from interpretation
+- Flag information needing verification
+- Recommend further research
+```
+
+### Tutor Mode
+
+```markdown
+---
+name: Tutor
+description: Interactive learning mode that guides rather than gives answers
+keep-coding-instructions: true
+---
+
+# Tutor Mode
+
+You are an educational tutor helping users learn by doing.
+
+## Teaching Approach
+
+- Guide discovery rather than providing answers
+- Ask leading questions
+- Break problems into smaller steps
+- Celebrate progress and correct gently
+- Adapt to the learner's level
+
+## Code Assistance
+
+When helping with code:
+- Mark sections for the user to complete: `// TODO(human): implement this`
+- Provide scaffolding, not complete solutions
+- Ask "What do you think should go here?"
+- Review their attempts constructively
+```
+
+---
+
+## Output Styles vs Other Features
+
+| Feature | Purpose | System Prompt Impact |
+|---------|---------|---------------------|
+| **Output Styles** | Change fundamental behavior | **Replaces** default prompt |
+| **CLAUDE.md** | Add project context | Adds as user context |
+| **`--append-system-prompt`** | Temporary additions | Appends to prompt |
+| **Agents** | Delegate specific tasks | Custom per agent |
+| **Commands** | Quick actions | No impact |
+
+---
+
+## When to Use Each
+
+| Scenario | Use |
+|----------|-----|
+| Change Claude's fundamental role | Output Styles |
+| Add project-specific context | CLAUDE.md |
+| One-time temporary instructions | `--append-system-prompt` |
+| Delegate specialized tasks | Agents |
+| Quick reusable prompts | Commands |
+
+---
+
+## Creating Custom Styles
+
+### Step 1: Choose Scope
+
+- **User** (`~/.claude/output-styles/`): Personal, all projects
+- **Project** (`.claude/output-styles/`): Team-shared, this project
+
+### Step 2: Create File
+
+```bash
+mkdir -p .claude/output-styles
+cat > .claude/output-styles/my-style.md << 'EOF'
+---
+name: My Custom Style
+description: What this style does
+keep-coding-instructions: false
+---
+
+# Instructions
+
+Your custom behavior instructions here...
+EOF
+```
+
+### Step 3: Test
+
+```bash
+/output-style my-style
+```
+
+---
+
+## Best Practices
+
+1. **Be specific**: Vague instructions get ignored
+2. **Define behaviors**: Explicit tone, format, approach
+3. **Include examples**: Show expected output patterns
+4. **Test thoroughly**: Try multiple prompts
+5. **Use clear names**: Indicate purpose in filename
+6. **Add descriptions**: Help others understand the style
+
+---
+
+## Related
+
+- [memory.md](memory.md) - CLAUDE.md for project context
+- [agents.md](agents.md) - Delegated specialists
+- [settings.md](settings.md) - Style configuration

--- a/claude-code/knowledge-base/overview.md
+++ b/claude-code/knowledge-base/overview.md
@@ -1,0 +1,214 @@
+# Claude Code > Overview
+
+> Architecture, context flow, and lifecycle of Claude Code's extensibility system.
+
+## Context Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         SESSION START                                │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐              │
+│  │  settings   │    │   Output    │    │    MCP      │              │
+│  │   .json     │    │   Style     │    │  Servers    │              │
+│  └──────┬──────┘    └──────┬──────┘    └──────┬──────┘              │
+│         │                  │                  │                      │
+│         ▼                  ▼                  ▼                      │
+│  ┌─────────────────────────────────────────────────────┐            │
+│  │              SYSTEM PROMPT LAYER                     │            │
+│  │  • Permissions (what Claude can do)                  │            │
+│  │  • Output style (how Claude behaves)                 │            │
+│  │  • Available tools (MCP + built-in)                  │            │
+│  └─────────────────────────────────────────────────────┘            │
+│                           │                                          │
+│         ┌─────────────────┼─────────────────┐                       │
+│         ▼                 ▼                 ▼                        │
+│  ┌─────────────┐   ┌─────────────┐   ┌─────────────┐               │
+│  │  CLAUDE.md  │   │   Rules     │   │   Skills    │               │
+│  │  (memory)   │   │  (filtered) │   │ (discovered)│               │
+│  └──────┬──────┘   └──────┬──────┘   └──────┬──────┘               │
+│         │                 │                 │                        │
+│         ▼                 ▼                 ▼                        │
+│  ┌─────────────────────────────────────────────────────┐            │
+│  │              USER CONTEXT LAYER                      │            │
+│  │  • Project knowledge (CLAUDE.md)                     │            │
+│  │  • Coding standards (rules, path-filtered)           │            │
+│  │  • Available capabilities (skills)                   │            │
+│  └─────────────────────────────────────────────────────┘            │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                      CONVERSATION RUNTIME                            │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  User Prompt ──► [Commands expand] ──► Claude Processing            │
+│                                              │                       │
+│                                              ▼                       │
+│                                    ┌─────────────────┐              │
+│                                    │   Tool Call     │              │
+│                                    └────────┬────────┘              │
+│                                             │                        │
+│                    ┌────────────────────────┼────────────────────┐  │
+│                    ▼                        ▼                    ▼  │
+│             ┌───────────┐           ┌───────────┐         ┌────────┐│
+│             │ PreToolUse│           │  Execute  │         │ Agents ││
+│             │   Hooks   │──block?──►│   Tool    │──spawn─►│(isolated)│
+│             └───────────┘           └─────┬─────┘         └────────┘│
+│                                           │                         │
+│                                           ▼                         │
+│                                    ┌───────────┐                    │
+│                                    │PostToolUse│                    │
+│                                    │   Hooks   │                    │
+│                                    └───────────┘                    │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## What Affects What
+
+```
+                    ┌─────────────────────────────────────────────────────────────┐
+                    │                    CLAUDE'S BRAIN                            │
+                    ├─────────────────────────────────────────────────────────────┤
+                    │                                                              │
+  REPLACES ───────► │  ┌─────────────────────────────────────────────────────┐   │
+  Output Styles     │  │            SYSTEM PROMPT                             │   │
+                    │  │  (Claude's core personality & instructions)          │   │
+                    │  └─────────────────────────────────────────────────────┘   │
+                    │                          │                                  │
+                    │                          ▼                                  │
+  ADDS TO ────────► │  ┌─────────────────────────────────────────────────────┐   │
+  CLAUDE.md         │  │            USER CONTEXT                              │   │
+  Rules             │  │  (What Claude knows about your project)              │   │
+  Skills (on invoke)│  └─────────────────────────────────────────────────────┘   │
+  Commands (expand) │                          │                                  │
+                    │                          ▼                                  │
+  CONFIGURES ─────► │  ┌─────────────────────────────────────────────────────┐   │
+  Settings          │  │            AVAILABLE TOOLS                           │   │
+  MCP               │  │  (What Claude can do - Read, Edit, Bash, etc.)       │   │
+  Plan Mode         │  └─────────────────────────────────────────────────────┘   │
+                    │                          │                                  │
+                    │                          ▼                                  │
+  INTERCEPTS ─────► │  ┌─────────────────────────────────────────────────────┐   │
+  Hooks             │  │            TOOL EXECUTION                            │   │
+                    │  │  (Block, modify, or react to tool calls)             │   │
+                    │  └─────────────────────────────────────────────────────┘   │
+                    │                                                              │
+                    └─────────────────────────────────────────────────────────────┘
+                                               │
+                                               │ Can delegate to
+                                               ▼
+                    ┌─────────────────────────────────────────────────────────────┐
+                    │                 ISOLATED AGENTS                              │
+                    ├─────────────────────────────────────────────────────────────┤
+                    │  • Fresh context (doesn't see main conversation)            │
+                    │  • Own tool restrictions                                     │
+                    │  • Can load Skills into their context                        │
+                    │  • Returns summary to main conversation                      │
+                    │  • Skills with context:fork run here                         │
+                    └─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Session Lifecycle
+
+```
+SESSION START                    CONVERSATION                         SESSION END
+     │                                │                                    │
+     ▼                                ▼                                    ▼
+┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐
+│Settings │  │CLAUDE.md│  │  User   │  │ Claude  │  │  Tool   │  │ Session │
+│ loaded  │─►│ Rules   │─►│ types   │─►│ thinks  │─►│executes │─►│  ends   │
+│         │  │ MCP     │  │ prompt  │  │         │  │         │  │         │
+│         │  │Out.Style│  │         │  │         │  │         │  │         │
+└─────────┘  └─────────┘  └─────────┘  └─────────┘  └─────────┘  └─────────┘
+                              │              │            │
+                              ▼              ▼            ▼
+                         ┌─────────┐   ┌─────────┐  ┌─────────┐
+                         │Commands │   │ Skills  │  │ Hooks   │
+                         │ expand  │   │ suggest │  │ fire    │
+                         │ here    │   │ Agents  │  │ Pre/Post│
+                         └─────────┘   │ spawn   │  └─────────┘
+                                       └─────────┘
+```
+
+---
+
+## Feature Loading Order
+
+### Memory Files
+1. `~/.claude/CLAUDE.md` (user global)
+2. `~/.claude/rules/*` (user rules)
+3. `./CLAUDE.md` or `./.claude/CLAUDE.md` (project)
+4. `./.claude/rules/*` (project rules)
+5. `./CLAUDE.local.md` (personal project)
+
+### Settings Precedence
+1. **Managed** (IT deployed) - highest priority
+2. **CLI flags** (current session)
+3. `.claude/settings.local.json` (personal project)
+4. `.claude/settings.json` (team project)
+5. `~/.claude/settings.json` (user global) - lowest priority
+
+Arrays merge (combine), objects deep-merge, primitives use highest priority.
+
+---
+
+## Isolated Execution
+
+### What "Isolated" Means
+
+Isolated = runs in a separate subprocess with fresh empty context.
+
+| Aspect | Main Context | Isolated Context |
+|--------|--------------|------------------|
+| Sees conversation history | Yes | No |
+| Shares context pollution | Yes | No |
+| Tool restrictions | From settings | From agent definition |
+| Returns | N/A | Summary only |
+
+### Skills ↔ Agents Relationship
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                                                             │
+│   SKILLS                              AGENTS                │
+│   ┌─────────┐                         ┌─────────┐           │
+│   │         │──"run me isolated"────► │  Agent  │           │
+│   │  Skill  │   (context: fork)       │  runs   │           │
+│   │         │   (agent: X)            │  skill  │           │
+│   │         │                         │         │           │
+│   │         │ ◄──"load these skills"──│         │           │
+│   │         │    (skills: X, Y)       │         │           │
+│   └─────────┘                         └─────────┘           │
+│                                                             │
+│   • Skills CANNOT spawn agents                              │
+│   • Skills CAN request to run inside an agent (isolated)    │
+│   • Agents CAN load skills into their own context           │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Feature Comparison Summary
+
+| Feature | Default Behavior | Can Run Isolated? | Has Tool Restrictions? |
+|---------|-----------------|-------------------|------------------------|
+| Rules | In your context | No | No |
+| Commands | In your context | Only with `context: fork` | Yes (`allowed-tools`) |
+| Skills | In your context | Yes (`context: fork`) | Yes (`allowed-tools`) |
+| Agents | Always isolated | Always | Yes (`tools`/`disallowedTools`) |
+
+---
+
+## Related
+
+- [index.md](index.md) - Feature matrix and navigation
+- [quick-reference.md](quick-reference.md) - Single-page cheat sheet

--- a/claude-code/knowledge-base/permissions.md
+++ b/claude-code/knowledge-base/permissions.md
@@ -1,0 +1,309 @@
+# Claude Code > Permissions
+
+> Permission modes and access control patterns.
+
+## Permission Modes
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `default` | Ask for permission on most operations | Normal development |
+| `acceptEdits` | Auto-accept file edits, ask for others | Trusted editing |
+| `dontAsk` | Minimal prompts (still asks for dangerous) | Fast iteration |
+| `bypassPermissions` | Skip all prompts | Automation |
+| `plan` | Read-only, blocks modifications | Safe exploration |
+
+---
+
+## Mode Selection
+
+### Via Settings
+
+```json
+{
+  "permissions": {
+    "defaultMode": "acceptEdits"
+  }
+}
+```
+
+### Via CLI
+
+```bash
+claude --permission-mode plan
+```
+
+### Via Keyboard
+
+`Shift+Tab` cycles through modes during session:
+1. **Normal** (default)
+2. **Auto-Accept** (`⏵⏵ accept edits on`)
+3. **Plan Mode** (`⏸ plan mode on`)
+
+---
+
+## Permission Rules
+
+### Rule Structure
+
+```json
+{
+  "permissions": {
+    "allow": [...],
+    "ask": [...],
+    "deny": [...]
+  }
+}
+```
+
+| List | Behavior |
+|------|----------|
+| `allow` | Auto-approve matching operations |
+| `ask` | Prompt for confirmation |
+| `deny` | Block without prompting |
+
+### Pattern Syntax
+
+| Pattern | Matches |
+|---------|---------|
+| `Tool` | All uses of the tool |
+| `Tool(pattern)` | Uses matching the exact pattern |
+| `Tool(prefix:*)` | Uses starting with prefix |
+| `Tool(*suffix)` | Uses ending with suffix |
+| `Tool(./path/**)` | Path glob patterns |
+
+### Examples
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm:*)",           // Any npm command
+      "Bash(git status:*)",    // git status only
+      "Read(./src/**)",        // Read anything in src/
+      "Edit(./src/**/*.ts)"    // Edit TypeScript in src/
+    ],
+    "deny": [
+      "Bash(rm -rf:*)",        // Block recursive delete
+      "Bash(sudo:*)",          // Block sudo
+      "Read(.env*)",           // Block env files
+      "Read(./secrets/**)"     // Block secrets directory
+    ]
+  }
+}
+```
+
+---
+
+## Tool Availability by Mode
+
+| Tool | default | acceptEdits | dontAsk | bypassPermissions | plan |
+|------|---------|-------------|---------|-------------------|------|
+| Read | Ask | Allow | Allow | Allow | Allow |
+| Glob | Ask | Allow | Allow | Allow | Allow |
+| Grep | Ask | Allow | Allow | Allow | Allow |
+| Edit | Ask | **Allow** | Allow | Allow | **Block** |
+| Write | Ask | **Allow** | Allow | Allow | **Block** |
+| Bash | Ask | Ask | Allow | Allow | **Block** |
+| WebFetch | Ask | Ask | Allow | Allow | **Block** |
+| WebSearch | Ask | Ask | Allow | Allow | **Block** |
+| Task | Ask | Allow | Allow | Allow | Allow |
+
+---
+
+## Plan Mode
+
+### Purpose
+
+Safe, read-only code analysis and planning before making changes.
+
+### Available Tools
+
+| Tool | Available | Why |
+|------|-----------|-----|
+| Read | Yes | Examine files |
+| Glob | Yes | Find files |
+| Grep | Yes | Search content |
+| AskUserQuestion | Yes | Gather requirements |
+| ExitPlanMode | Yes | Signal ready to implement |
+
+### Blocked Tools
+
+| Tool | Why Blocked |
+|------|-------------|
+| Edit | Modifies files |
+| Write | Creates/overwrites files |
+| Bash | Can execute arbitrary commands |
+| WebFetch | External requests |
+| WebSearch | External requests |
+
+### Entering Plan Mode
+
+```bash
+# Start in plan mode
+claude --permission-mode plan
+
+# Or toggle with keyboard
+Shift+Tab
+```
+
+---
+
+## Additional Directories
+
+Expand Claude's file access beyond the project:
+
+```json
+{
+  "permissions": {
+    "additionalDirectories": [
+      "../shared-docs/",
+      "../other-project/",
+      "~/reference-code/"
+    ]
+  }
+}
+```
+
+---
+
+## Sandbox Mode
+
+Isolate Claude's operations in a secure sandbox:
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "excludedCommands": ["git", "docker"],
+    "allowUnsandboxedCommands": true,
+    "network": {
+      "allowUnixSockets": ["~/.ssh/agent-socket"],
+      "allowLocalBinding": true
+    }
+  }
+}
+```
+
+| Setting | Description |
+|---------|-------------|
+| `enabled` | Enable sandbox mode |
+| `autoAllowBashIfSandboxed` | Auto-approve Bash when sandboxed |
+| `excludedCommands` | Commands that bypass sandbox |
+| `allowUnsandboxedCommands` | Allow some commands outside sandbox |
+
+---
+
+## Disabling Bypass Mode
+
+Prevent use of `bypassPermissions`:
+
+```json
+{
+  "permissions": {
+    "disableBypassPermissionsMode": "disable"
+  }
+}
+```
+
+---
+
+## Agent Permissions
+
+Agents can have their own permission modes:
+
+```yaml
+---
+name: security-auditor
+permissionMode: plan
+tools: Read, Grep, Glob
+disallowedTools: Write, Edit, Bash
+---
+```
+
+| Field | Description |
+|-------|-------------|
+| `permissionMode` | Override mode for this agent |
+| `tools` | Allowed tools (whitelist) |
+| `disallowedTools` | Denied tools (blacklist) |
+
+---
+
+## Use Case Examples
+
+### Security-Focused Project
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read(./src/**)",
+      "Edit(./src/**)",
+      "Bash(npm run lint:*)",
+      "Bash(npm test:*)"
+    ],
+    "deny": [
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(nc:*)",
+      "Read(.env*)",
+      "WebFetch"
+    ]
+  },
+  "sandbox": {
+    "enabled": true
+  }
+}
+```
+
+### Read-Only Analysis
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Bash(git log:*)",
+      "Bash(git show:*)"
+    ],
+    "deny": [
+      "Write",
+      "Edit",
+      "Bash(git commit:*)",
+      "Bash(git push:*)"
+    ],
+    "defaultMode": "plan"
+  }
+}
+```
+
+### CI/CD Automation
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm:*)",
+      "Bash(git:*)",
+      "Read",
+      "Edit",
+      "Write"
+    ],
+    "deny": [
+      "Bash(sudo:*)",
+      "Bash(rm -rf /*:*)"
+    ],
+    "defaultMode": "bypassPermissions"
+  }
+}
+```
+
+---
+
+## Related
+
+- [settings.md](settings.md) - Full settings reference
+- [plan-mode.md](plan-mode.md) - Plan mode details
+- [agents.md](agents.md) - Agent permission configuration

--- a/claude-code/knowledge-base/plan-mode.md
+++ b/claude-code/knowledge-base/plan-mode.md
@@ -1,0 +1,278 @@
+# Claude Code > Plan Mode
+
+> Read-only analysis mode for safe exploration.
+
+## Purpose
+
+Plan Mode enables:
+- **Safe exploration**: Analyze codebases without risk of changes
+- **Thorough planning**: Create detailed plans before implementation
+- **Interactive clarification**: Ask questions to gather requirements
+- **Architecture decisions**: Think through complex problems step-by-step
+
+---
+
+## When to Use
+
+| Scenario | Why Plan Mode Helps |
+|----------|---------------------|
+| Multi-file features | Plan the approach before touching many files |
+| Complex refactoring | Understand dependencies and plan migration |
+| Code exploration | Research without accidentally modifying |
+| Architecture decisions | Evaluate options before committing |
+| Onboarding to codebase | Learn structure safely |
+
+---
+
+## Entering Plan Mode
+
+### Keyboard Toggle
+
+```
+Shift+Tab    # Cycles through permission modes
+```
+
+Mode cycle:
+1. **Normal** → asks for permission on each action
+2. **Auto-Accept** (`⏵⏵ accept edits on`) → auto-approves changes
+3. **Plan Mode** (`⏸ plan mode on`) → read-only analysis
+
+### CLI Flag
+
+```bash
+claude --permission-mode plan
+```
+
+### Headless Plan Mode
+
+```bash
+claude --permission-mode plan -p "Analyze the auth system and suggest improvements"
+```
+
+### Via Settings
+
+```json
+{
+  "permissions": {
+    "defaultMode": "plan"
+  }
+}
+```
+
+---
+
+## Tools Available
+
+### Allowed (Read-Only)
+
+| Tool | Purpose |
+|------|---------|
+| `Read` | Examine file contents |
+| `Glob` | Find files by pattern |
+| `Grep` | Search for patterns |
+| `AskUserQuestion` | Ask clarifying questions |
+| `ExitPlanMode` | Signal ready to implement |
+
+### Blocked (Modifications)
+
+| Tool | Why Blocked |
+|------|-------------|
+| `Edit` | Modifies files |
+| `Write` | Creates/overwrites files |
+| `Bash` | Can execute arbitrary commands |
+| `WebFetch` | External requests |
+| `WebSearch` | External requests |
+
+---
+
+## Plans Directory
+
+### Default Location
+
+```
+~/.claude/plans/
+```
+
+Plans are stored at user level by default.
+
+### Custom Location
+
+Configure in `.claude/settings.json`:
+
+```json
+{
+  "plansDirectory": "./plans"
+}
+```
+
+This stores plans in the project directory instead.
+
+---
+
+## Workflow
+
+### 1. Enter Plan Mode
+
+```bash
+claude --permission-mode plan
+```
+
+### 2. Describe the Task
+
+```
+> I need to refactor our authentication system to use OAuth2.
+  Create a detailed migration plan.
+```
+
+### 3. Claude Analyzes
+
+Claude will:
+- Read relevant files
+- Search for patterns
+- Map dependencies
+- Ask clarifying questions
+
+### 4. Answer Clarifying Questions
+
+Claude uses `AskUserQuestion` to gather requirements:
+
+```
+Claude: What OAuth2 providers should we support?
+  [ ] Google
+  [ ] GitHub
+  [ ] Microsoft
+  [ ] Custom OIDC
+
+Claude: Should we maintain backward compatibility with existing sessions?
+  [ ] Yes, migrate gradually
+  [ ] No, clean cutover
+```
+
+### 5. Receive the Plan
+
+Claude provides a detailed implementation plan with:
+- Step-by-step approach
+- Files to modify
+- Potential risks
+- Testing strategy
+
+### 6. Exit Plan Mode
+
+When ready to implement:
+- Press `Shift+Tab` to switch to Normal or Auto-Accept mode
+- Or start a new session without `--permission-mode plan`
+
+---
+
+## OpusPlan Model
+
+The `opusplan` model alias provides hybrid planning:
+- **Plan Mode**: Uses Claude Opus (superior reasoning)
+- **Execution Mode**: Switches to Claude Sonnet (efficient coding)
+
+```bash
+claude --model opusplan
+```
+
+Or in settings:
+
+```json
+{
+  "model": "opusplan"
+}
+```
+
+---
+
+## Example Session
+
+```
+$ claude --permission-mode plan
+
+> Analyze the codebase and create a plan to add real-time notifications
+
+Claude: I'll analyze the codebase to understand the current architecture
+and create a comprehensive plan for adding real-time notifications.
+
+[Reads package.json, src/config/, src/services/]
+
+Claude: I have a few questions to clarify the requirements:
+
+1. What notification channels do you need?
+   [ ] In-app only
+   [ ] In-app + Email
+   [ ] In-app + Email + Push
+
+2. What's the expected scale?
+   [ ] < 1,000 concurrent users
+   [ ] 1,000 - 10,000 concurrent users
+   [ ] > 10,000 concurrent users
+
+> In-app + Email, 1,000 - 10,000 users
+
+Claude: Based on my analysis, here's the implementation plan:
+
+## Phase 1: Infrastructure Setup
+1. Add Redis for pub/sub messaging
+2. Create WebSocket server module
+3. Set up notification queue
+
+## Phase 2: Core Implementation
+1. Create notification service (src/services/notification.ts)
+2. Add WebSocket connection handler
+3. Implement notification types and templates
+
+...
+
+Ready to proceed with implementation?
+
+> Yes, let's start with Phase 1
+
+[Press Shift+Tab to exit Plan Mode and begin implementation]
+```
+
+---
+
+## Encouraging Questions in CLAUDE.md
+
+Add to your project's `CLAUDE.md`:
+
+```markdown
+## Planning Guidelines
+
+Always ask clarifying questions when:
+- Multiple valid approaches exist
+- Requirements are ambiguous
+- Trade-offs need consideration
+- Scale/performance requirements are unclear
+```
+
+---
+
+## Plan Mode vs Other Modes
+
+| Feature | Plan Mode | Normal | Auto-Accept |
+|---------|-----------|--------|-------------|
+| Read files | Yes | Yes | Yes |
+| Search code | Yes | Yes | Yes |
+| Edit files | **No** | Ask | Yes |
+| Run commands | **No** | Ask | Ask |
+| Web requests | **No** | Ask | Ask |
+| Ask questions | Yes | Yes | Yes |
+
+---
+
+## Best Practices
+
+1. **Start complex tasks in Plan Mode**: Get alignment before coding
+2. **Use OpusPlan for architecture**: Better reasoning for planning
+3. **Answer questions thoughtfully**: Better input = better plans
+4. **Iterate on plans**: Refine before switching to execution
+5. **Save plans for reference**: Configure `plansDirectory` for persistence
+
+---
+
+## Related
+
+- [permissions.md](permissions.md) - Permission modes
+- [settings.md](settings.md) - Configuration options

--- a/claude-code/knowledge-base/quick-reference.md
+++ b/claude-code/knowledge-base/quick-reference.md
@@ -1,0 +1,313 @@
+# Claude Code > Quick Reference
+
+> Single-page cheat sheet for all Claude Code extensibility features.
+
+---
+
+## File Locations
+
+| File | Purpose |
+|------|---------|
+| `.claude/settings.json` | Team configuration |
+| `.claude/settings.local.json` | Personal overrides (gitignored) |
+| `~/.claude/settings.json` | User global settings |
+| `./CLAUDE.md` | Project memory |
+| `./CLAUDE.local.md` | Personal memory (gitignored) |
+| `~/.claude/CLAUDE.md` | User global memory |
+| `.claude/rules/*.md` | Modular rules |
+| `.claude/commands/*.md` | Slash commands |
+| `.claude/skills/*/SKILL.md` | Skills |
+| `.claude/agents/*.md` | Subagents |
+| `.claude/output-styles/*.md` | Output styles |
+| `.mcp.json` | MCP servers |
+
+---
+
+## Feature Quick Guide
+
+| Need | Use | Why |
+|------|-----|-----|
+| Project context | CLAUDE.md | Always loaded |
+| Coding standards | Rules | Path-filtered, modular |
+| Quick prompt shortcut | Command | Explicit invocation |
+| Complex procedure | Skill | Auto-discoverable |
+| Isolated specialist | Agent | Separate context |
+| Block/log tool calls | Hook | Enforcement |
+| External services | MCP | Database, API access |
+| Change Claude's role | Output Style | Replaces system prompt |
+| Safe exploration | Plan Mode | Blocks modifications |
+
+---
+
+## Frontmatter Reference
+
+### Commands (`.claude/commands/*.md`)
+
+```yaml
+---
+description: Shown in /help
+argument-hint: [arg1] [arg2]
+allowed-tools: Bash(git:*), Read
+model: haiku
+context: fork
+agent: code-simplifier
+disable-model-invocation: true
+---
+```
+
+### Skills (`.claude/skills/*/SKILL.md`)
+
+```yaml
+---
+name: skill-name
+description: When to use (keyword-rich)
+allowed-tools: Read, Grep, Glob, Bash
+model: opus
+context: fork
+agent: general-purpose
+user-invocable: true
+disable-model-invocation: false
+---
+```
+
+### Agents (`.claude/agents/*.md`)
+
+```yaml
+---
+name: agent-name
+description: When to delegate
+tools: Read, Grep, Glob
+disallowedTools: Write, Edit, Bash
+model: sonnet
+permissionMode: plan
+skills: skill1, skill2
+---
+```
+
+### Rules (`.claude/rules/*.md`)
+
+```yaml
+---
+paths:
+  - "src/**/*.ts"
+  - "test/**/*.spec.ts"
+---
+```
+
+### Output Styles (`.claude/output-styles/*.md`)
+
+```yaml
+---
+name: Display Name
+description: Shown in menu
+keep-coding-instructions: false
+---
+```
+
+---
+
+## Permission Patterns
+
+```
+Tool                    # All uses
+Tool(pattern)           # Exact match
+Tool(prefix:*)          # Starts with
+Tool(*suffix)           # Ends with
+Tool(./path/**)         # Path glob
+```
+
+### Examples
+
+```json
+{
+  "allow": [
+    "Bash(npm:*)",
+    "Bash(git status:*)",
+    "Read(./src/**)",
+    "Edit(./src/**/*.ts)"
+  ],
+  "deny": [
+    "Bash(rm -rf:*)",
+    "Read(.env*)"
+  ]
+}
+```
+
+---
+
+## Hook Events
+
+| Event | When | Exit 2 = |
+|-------|------|----------|
+| `PreToolUse` | Before tool | Block |
+| `PostToolUse` | After tool | (ignored) |
+| `PermissionRequest` | Permission prompt | Deny |
+| `UserPromptSubmit` | User input | (n/a) |
+| `Notification` | Needs attention | (n/a) |
+| `Stop` | Response complete | (n/a) |
+| `SubagentStop` | Subagent done | (n/a) |
+| `SessionStart` | Session begins | (n/a) |
+| `SessionEnd` | Session ends | (n/a) |
+
+### Hook Template
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "./script.sh"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## MCP Server Types
+
+### HTTP
+
+```json
+{
+  "type": "http",
+  "url": "https://api.example.com/mcp",
+  "headers": {"Authorization": "Bearer ${TOKEN}"}
+}
+```
+
+### Stdio
+
+```json
+{
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "@package/name"],
+  "env": {"VAR": "${VALUE}"}
+}
+```
+
+---
+
+## Permission Modes
+
+| Mode | Edits | Bash | Description |
+|------|-------|------|-------------|
+| `default` | Ask | Ask | Normal |
+| `acceptEdits` | Auto | Ask | Fast editing |
+| `dontAsk` | Auto | Auto | Minimal prompts |
+| `bypassPermissions` | Auto | Auto | Skip all |
+| `plan` | Block | Block | Read-only |
+
+---
+
+## Dynamic Content (Commands/Skills)
+
+| Syntax | Purpose | Example |
+|--------|---------|---------|
+| `$ARGUMENTS` | All args | `Fix $ARGUMENTS` |
+| `$1`, `$2` | Positional | `Issue #$1` |
+| `` !`cmd` `` | Bash output | `` !`git status` `` |
+| `@path` | File content | `@README.md` |
+
+---
+
+## Path Glob Patterns
+
+| Pattern | Matches |
+|---------|---------|
+| `**/*.ts` | All .ts files |
+| `src/**/*` | Everything in src/ |
+| `*.md` | Root markdown only |
+| `{a,b}/**` | a/ or b/ |
+| `!**/node_modules/**` | Exclude |
+
+---
+
+## Key Insights
+
+> **Rules = suggestions. Hooks = enforcement.**
+
+> **Skills with `context: fork` run in agents.**
+
+> **Warn hook messages only reach user, not Claude.**
+
+> **Agents always run isolated; skills optionally.**
+
+---
+
+## Activation Comparison
+
+| Feature | When Loaded | Auto-Trigger? |
+|---------|-------------|---------------|
+| Settings | Pre-session | Always |
+| CLAUDE.md | Session start | Always |
+| Rules | Session start | Always |
+| Commands | On `/cmd` | No |
+| Skills | On suggest/invoke | Optional |
+| Agents | On delegation | Optional |
+| Hooks | Per tool call | Always |
+| Output Styles | On activate | No |
+
+---
+
+## Tool Availability
+
+| Tool | Default | Plan Mode |
+|------|---------|-----------|
+| Read | Yes | Yes |
+| Glob | Yes | Yes |
+| Grep | Yes | Yes |
+| Edit | Yes | **No** |
+| Write | Yes | **No** |
+| Bash | Yes | **No** |
+| WebFetch | Yes | **No** |
+| Task | Yes | Yes |
+
+---
+
+## Common Configurations
+
+### Security-Focused
+
+```json
+{
+  "permissions": {
+    "deny": ["Bash(curl:*)", "Bash(wget:*)", "Read(.env*)"]
+  },
+  "sandbox": {"enabled": true}
+}
+```
+
+### Read-Only Analysis
+
+```json
+{
+  "permissions": {
+    "deny": ["Write", "Edit", "Bash(git commit:*)"],
+    "defaultMode": "plan"
+  }
+}
+```
+
+### Fast Development
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(npm:*)", "Bash(git:*)", "Edit", "Write"],
+    "defaultMode": "acceptEdits"
+  }
+}
+```
+
+---
+
+## Related Files
+
+- [index.md](index.md) - Full navigation
+- [overview.md](overview.md) - Architecture diagrams

--- a/claude-code/knowledge-base/rules.md
+++ b/claude-code/knowledge-base/rules.md
@@ -1,0 +1,211 @@
+# Claude Code > Rules
+
+> Modular instruction files in `.claude/rules/`.
+
+## Directory Structure
+
+```
+.claude/rules/
+├── code-style.md           # General coding standards
+├── testing.md              # Testing conventions
+├── security.md             # Security requirements
+├── api-design.md           # API guidelines
+└── frontend/
+    ├── react.md            # React-specific rules
+    └── styling.md          # CSS/styling rules
+```
+
+## Scope Locations
+
+| Location | Scope | Shared |
+|----------|-------|--------|
+| `.claude/rules/` | Project (team) | Yes (committed) |
+| `~/.claude/rules/` | User (personal) | No |
+
+---
+
+## Rule File Format
+
+### Basic Rule (applies to all files)
+
+```markdown
+# Security Requirements
+
+- Never commit secrets or API keys
+- Always validate user input
+- Use parameterized queries for database operations
+- Implement proper error handling without exposing internals
+```
+
+### Path-Specific Rule
+
+Use YAML frontmatter to restrict rules to specific file patterns:
+
+```markdown
+---
+paths:
+  - "src/api/**/*.ts"
+  - "src/middleware/**/*.ts"
+---
+
+# API Development Rules
+
+- All endpoints must include input validation
+- Use the standard error response format
+- Include OpenAPI documentation comments
+- Follow REST conventions for HTTP methods
+```
+
+---
+
+## Path Pattern Syntax
+
+| Pattern | Matches |
+|---------|---------|
+| `**/*.ts` | All TypeScript files in any directory |
+| `src/**/*` | All files under src/ |
+| `*.md` | Markdown files in project root only |
+| `{src,lib}/**/*.ts` | TypeScript in src/ or lib/ |
+| `test/**/*.test.ts` | Test files in test directory |
+| `!**/node_modules/**` | Exclude node_modules |
+
+---
+
+## Examples
+
+### Code Style Rules
+
+```markdown
+# .claude/rules/code-style.md
+
+---
+paths:
+  - "src/**/*.{ts,tsx}"
+---
+
+# TypeScript Style Guide
+
+## Naming Conventions
+- Use PascalCase for types, interfaces, and classes
+- Use camelCase for variables, functions, and methods
+- Use UPPER_SNAKE_CASE for constants
+
+## Code Organization
+- One component per file
+- Group imports: external, internal, relative
+- Export types separately from implementations
+
+## Best Practices
+- Prefer `const` over `let`
+- Use strict TypeScript settings
+- Avoid `any` type - use `unknown` when type is truly unknown
+```
+
+### Testing Rules
+
+```markdown
+# .claude/rules/testing.md
+
+---
+paths:
+  - "test/**/*.test.ts"
+  - "src/**/*.spec.ts"
+  - "**/__tests__/**"
+---
+
+# Testing Guidelines
+
+## File Naming
+- Test files: `{name}.test.ts` or `{name}.spec.ts`
+- One test file per source file
+
+## Test Structure
+- Use descriptive test names that explain the scenario
+- Follow Arrange-Act-Assert pattern
+- One assertion per test when possible
+
+## Coverage Requirements
+- Minimum 80% code coverage
+- 100% coverage for critical paths
+```
+
+### Security Rules
+
+```markdown
+# .claude/rules/security.md
+
+# Security Requirements
+
+These rules apply to ALL files in the project.
+
+## Secrets Management
+- NEVER hardcode secrets, API keys, or credentials
+- Use environment variables for all sensitive values
+- Never log sensitive information
+
+## Input Validation
+- Validate all user input at system boundaries
+- Use allowlists over denylists
+- Sanitize data before database operations
+```
+
+---
+
+## Rules vs CLAUDE.md
+
+| Aspect | `CLAUDE.md` | `.claude/rules/` |
+|--------|-------------|------------------|
+| Structure | Single file | Multiple files |
+| Organization | Sections | Separate files |
+| Path targeting | No | Yes (frontmatter) |
+| Best for | Project overview | Detailed guidelines |
+| Maintenance | Can get unwieldy | Modular and focused |
+
+**Recommendation**: Use `CLAUDE.md` for high-level project context and `.claude/rules/` for detailed coding standards.
+
+---
+
+## Rules vs Skills: Activation Model
+
+| Aspect | Rules | Skills |
+|--------|-------|--------|
+| **Loading** | Always in context | On-demand (lazy) |
+| **Activation** | Deterministic | Probabilistic or explicit |
+| **Context cost** | Always paid | Only when invoked |
+| **Best for** | Universal conventions | Task-specific procedures |
+
+---
+
+## Key Insight
+
+> **Rules are suggestions that the LLM weighs against other context. Hooks are enforcement.**
+>
+> A rule saying "don't edit .env" is parsed by Claude and *maybe* followed.
+> A PreToolUse hook blocking .env edits *always* runs and blocks the operation.
+
+---
+
+## Loading Behavior
+
+- All rules in `.claude/rules/` are loaded at session start
+- Path-specific rules are filtered based on current context
+- User rules (`~/.claude/rules/`) load after project rules
+- No explicit ordering - keep rules non-conflicting
+
+---
+
+## Best Practices
+
+1. **Keep rules focused**: Each file covers ONE topic
+2. **Be specific**: Vague rules get ignored; specific rules get followed
+3. **Include examples**: Show code examples of good/bad patterns
+4. **Use path patterns sparingly**: Rules without `paths` apply globally
+5. **Review regularly**: Update rules as project conventions evolve
+
+---
+
+## Related
+
+- [memory.md](memory.md) - CLAUDE.md memory files
+- [skills.md](skills.md) - On-demand capabilities
+- [hooks.md](hooks.md) - Enforcement via hooks

--- a/claude-code/knowledge-base/settings.md
+++ b/claude-code/knowledge-base/settings.md
@@ -1,0 +1,300 @@
+# Claude Code > Settings
+
+> Configuration via `settings.json` files.
+
+## File Locations
+
+| File | Scope | Shared | Priority |
+|------|-------|--------|----------|
+| Managed settings | System-wide (IT deployed) | N/A | 1 (highest) |
+| `.claude/settings.local.json` | Personal project | No (gitignored) | 2 |
+| `.claude/settings.json` | Team project | Yes (committed) | 3 |
+| `~/.claude/settings.json` | User global | No | 4 (lowest) |
+
+---
+
+## Permissions
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run:*)",
+      "Bash(git commit:*)",
+      "Read(./src/**)",
+      "Edit(./src/**)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Write(./)"
+    ],
+    "deny": [
+      "Bash(rm -rf:*)",
+      "Read(.env)",
+      "Read(.env.*)"
+    ],
+    "additionalDirectories": [
+      "../shared-docs/",
+      "../other-project/"
+    ],
+    "defaultMode": "acceptEdits"
+  }
+}
+```
+
+### Permission Rule Syntax
+
+| Pattern | Matches |
+|---------|---------|
+| `Tool` | All uses of the tool |
+| `Tool(pattern)` | Uses matching pattern |
+| `Tool(prefix:*)` | Uses starting with prefix |
+| `Tool(*suffix)` | Uses ending with suffix |
+| `Tool(./path/**)` | Path glob patterns |
+
+### Default Modes
+
+| Mode | Behavior |
+|------|----------|
+| `default` | Ask for permission on most operations |
+| `acceptEdits` | Auto-accept file edits, ask for others |
+| `dontAsk` | Minimal prompts (still asks for dangerous ops) |
+| `bypassPermissions` | Skip all prompts |
+| `plan` | Research only, no edits |
+
+---
+
+## Sandbox
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "excludedCommands": ["git", "docker"],
+    "allowUnsandboxedCommands": true,
+    "network": {
+      "allowUnixSockets": ["~/.ssh/agent-socket"],
+      "allowLocalBinding": true,
+      "httpProxyPort": 8080,
+      "socksProxyPort": 8081
+    }
+  }
+}
+```
+
+---
+
+## Model Configuration
+
+```json
+{
+  "model": "claude-opus-4-5-20251101",
+  "alwaysThinkingEnabled": true
+}
+```
+
+| Model | Description |
+|-------|-------------|
+| `claude-opus-4-5-20251101` | Most capable |
+| `claude-sonnet-4-20250514` | Balanced |
+| `claude-haiku-4-5-20251001` | Fastest |
+| `opusplan` | Opus for planning, Sonnet for execution |
+
+---
+
+## Environment Variables
+
+```json
+{
+  "env": {
+    "NODE_ENV": "development",
+    "DEBUG": "true",
+    "CUSTOM_VAR": "value"
+  }
+}
+```
+
+---
+
+## Hooks
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/validate-bash.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx prettier --write \"$FILE_PATH\""
+          }
+        ]
+      }
+    ]
+  },
+  "disableAllHooks": false,
+  "allowManagedHooksOnly": false
+}
+```
+
+---
+
+## MCP Servers
+
+```json
+{
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["memory", "github"],
+  "disabledMcpjsonServers": ["filesystem"]
+}
+```
+
+---
+
+## Plugins
+
+```json
+{
+  "enabledPlugins": {
+    "code-simplifier@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true
+  },
+  "extraKnownMarketplaces": {
+    "acme-tools": {
+      "source": {
+        "source": "github",
+        "repo": "acme-corp/claude-plugins"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Attribution
+
+```json
+{
+  "attribution": {
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "Generated with Claude Code"
+  }
+}
+```
+
+---
+
+## Miscellaneous
+
+```json
+{
+  "cleanupPeriodDays": 30,
+  "plansDirectory": "~/.claude/plans",
+  "showTurnDuration": true,
+  "language": "english",
+  "autoUpdatesChannel": "stable",
+  "spinnerTipsEnabled": true,
+  "terminalProgressBarEnabled": true,
+  "respectGitignore": true
+}
+```
+
+---
+
+## Complete Example
+
+### Team Settings (`.claude/settings.json`)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run:*)",
+      "Bash(npm test:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Read(./src/**)",
+      "Read(./test/**)",
+      "Edit(./src/**)",
+      "Edit(./test/**)"
+    ],
+    "deny": [
+      "Bash(rm -rf:*)",
+      "Read(.env*)",
+      "Read(./secrets/**)"
+    ],
+    "defaultMode": "acceptEdits"
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx prettier --write \"$FILE_PATH\" 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  },
+  "attribution": {
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>"
+  }
+}
+```
+
+### Personal Overrides (`.claude/settings.local.json`)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(my-custom-script:*)"
+    ]
+  },
+  "env": {
+    "MY_API_KEY": "personal-key-here"
+  },
+  "model": "claude-opus-4-5-20251101",
+  "alwaysThinkingEnabled": true
+}
+```
+
+---
+
+## Settings Inheritance
+
+Settings merge with this priority (highest to lowest):
+
+1. **Managed** - System-wide policies (IT deployed)
+2. **Command line** - CLI flags for current session
+3. **Local** - `.claude/settings.local.json`
+4. **Project** - `.claude/settings.json`
+5. **User** - `~/.claude/settings.json`
+
+Arrays are merged (combined), objects are deep-merged, primitives use highest priority.
+
+---
+
+## Related
+
+- [permissions.md](permissions.md) - Permission modes in detail
+- [hooks.md](hooks.md) - Hook configuration
+- [mcp.md](mcp.md) - MCP server configuration

--- a/claude-code/knowledge-base/skills.md
+++ b/claude-code/knowledge-base/skills.md
@@ -1,0 +1,305 @@
+# Claude Code > Skills
+
+> Reusable capabilities in `.claude/skills/`.
+
+## Directory Structure
+
+```
+.claude/skills/
+├── code-review/
+│   ├── SKILL.md              # Required: main skill definition
+│   ├── CHECKLIST.md          # Supporting documentation
+│   └── examples.md           # Usage examples
+├── pdf-processing/
+│   ├── SKILL.md
+│   └── scripts/
+│       ├── fill_form.py
+│       └── validate.py
+└── commit-helper/
+    └── SKILL.md              # Simple skill (single file)
+```
+
+## Scope Locations
+
+| Location | Scope | Shared |
+|----------|-------|--------|
+| `.claude/skills/` | Project (team) | Yes (committed) |
+| `~/.claude/skills/` | User (personal) | No |
+
+---
+
+## SKILL.md Format
+
+### Basic Skill
+
+```markdown
+---
+name: code-review
+description: Reviews code for quality, security, and maintainability issues
+---
+
+# Code Review
+
+When reviewing code, analyze:
+1. Logic errors and bugs
+2. Security vulnerabilities
+3. Performance issues
+4. Code style and readability
+5. Test coverage gaps
+
+Provide specific, actionable feedback with code examples.
+```
+
+### Full-Featured Skill
+
+```yaml
+---
+name: security-audit
+description: Performs security audits on codebases. Checks for OWASP vulnerabilities, secrets exposure, and insecure patterns.
+allowed-tools: Read, Grep, Glob, Bash
+model: opus
+context: fork
+agent: general-purpose
+user-invocable: true
+disable-model-invocation: false
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate-readonly.sh"
+---
+
+# Security Audit Skill
+
+## Scope
+
+This skill performs comprehensive security audits including:
+- OWASP Top 10 vulnerability scanning
+- Secrets and credential detection
+- Dependency vulnerability analysis
+- Authentication/authorization review
+
+## Process
+
+1. Scan for hardcoded secrets
+2. Check dependency vulnerabilities
+3. Review authentication flows
+4. Analyze input validation
+5. Check for injection vulnerabilities
+```
+
+---
+
+## Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier (lowercase, hyphens, max 64 chars) |
+| `description` | Yes | When to use (keyword-rich for discovery, max 1024 chars) |
+| `allowed-tools` | No | Comma-separated tools: `Read, Grep, Glob, Bash` |
+| `model` | No | Model override: `sonnet`, `opus`, `haiku` |
+| `context` | No | `fork` for isolated subagent context |
+| `agent` | No | Agent type when `context: fork` |
+| `user-invocable` | No | Show in `/help` (default: true) |
+| `disable-model-invocation` | No | Prevent auto-invocation (default: false) |
+| `hooks` | No | PreToolUse/PostToolUse hooks |
+
+---
+
+## Activation Model
+
+### Soft vs Strong Activation
+
+| Type | Description | When to Use |
+|------|-------------|-------------|
+| **Soft** | Claude *could* auto-invoke via description matching | Context-dependent procedures |
+| **Strong** | Explicitly called (`/skill`) or referenced in agent .md | Predictable workflows |
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     SKILL ACTIVATION                             │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  SOFT (probabilistic)              STRONG (deterministic)        │
+│  ┌─────────────────────┐          ┌─────────────────────┐       │
+│  │ User says "deploy"  │          │ User types /deploy  │       │
+│  │         ↓           │          │         ↓           │       │
+│  │ Claude checks       │          │ Skill loads         │       │
+│  │ skill descriptions  │          │ immediately         │       │
+│  │         ↓           │          │                     │       │
+│  │ Maybe suggests      │          │                     │       │
+│  │ deploy skill        │          │                     │       │
+│  └─────────────────────┘          └─────────────────────┘       │
+│                                                                  │
+│  • May not trigger                 • Always triggers             │
+│  • Depends on description          • Explicit invocation         │
+│  • Context-dependent               • User-controlled             │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### When to Use Each
+
+| Scenario | Activation | Settings |
+|----------|------------|----------|
+| Common workflow user remembers | Strong (`/skill`) | Default |
+| Context-dependent procedure | Soft (auto) | Default |
+| Background reference | Soft | `user-invocable: false` |
+| Dangerous operations | Strong only | `disable-model-invocation: true` |
+
+---
+
+## String Substitutions
+
+| Variable | Description |
+|----------|-------------|
+| `$ARGUMENTS` | All arguments passed to the skill |
+| `$1`, `$2`, etc. | Positional arguments |
+| `${CLAUDE_SESSION_ID}` | Current session ID |
+
+```markdown
+---
+name: log-activity
+description: Logs activity to session-specific file
+---
+
+Log the following to logs/${CLAUDE_SESSION_ID}.log:
+
+Activity: $ARGUMENTS
+Timestamp: $(date)
+```
+
+---
+
+## Progressive Disclosure Pattern
+
+For complex skills, keep `SKILL.md` concise and link to supporting files:
+
+```
+my-skill/
+├── SKILL.md              # Overview (<500 lines)
+├── reference.md          # Detailed API/reference docs
+├── examples.md           # Usage examples
+├── templates/
+│   ├── template1.md
+│   └── template2.md
+└── scripts/
+    ├── helper.py
+    └── validate.sh
+```
+
+**In SKILL.md:**
+
+```markdown
+## Quick Start
+
+Specify the resource name and fields:
+/api-generator users name:string email:string:unique
+
+## Resources
+
+- **Full Reference**: See [reference.md](reference.md) for all options
+- **Examples**: See [examples.md](examples.md) for common patterns
+```
+
+---
+
+## Examples
+
+### Simple Commit Helper
+
+```markdown
+# .claude/skills/commit-helper/SKILL.md
+
+---
+name: commit-helper
+description: Generates conventional commit messages from staged changes
+allowed-tools: Bash
+---
+
+# Commit Message Helper
+
+## Process
+
+1. Run `git diff --cached` to see staged changes
+2. Analyze the changes
+3. Generate a commit message:
+   - `feat:` for new features
+   - `fix:` for bug fixes
+   - `docs:` for documentation
+   - `refactor:` for refactoring
+   - `test:` for tests
+   - `chore:` for maintenance
+```
+
+### Isolated Skill with Subagent
+
+```markdown
+# .claude/skills/parallel-research/SKILL.md
+
+---
+name: parallel-research
+description: Researches multiple topics in parallel using subagents
+context: fork
+agent: general-purpose
+allowed-tools: WebSearch, WebFetch, Read
+---
+
+# Parallel Research
+
+This skill spawns isolated subagents to research topics concurrently.
+
+## Usage
+
+/parallel-research "topic1" "topic2" "topic3"
+
+## Output Format
+
+For each topic:
+- **Summary**: 2-3 sentence overview
+- **Key Findings**: Bullet points
+- **Sources**: Links to references
+```
+
+---
+
+## Skills vs Commands vs Agents
+
+| Aspect | Commands | Skills | Agents |
+|--------|----------|--------|--------|
+| **Structure** | Single `.md` | Directory with `SKILL.md` | Single `.md` |
+| **Discovery** | Explicit (`/name`) | Automatic + explicit | Task delegation |
+| **Complexity** | Simple prompts | Multi-file capabilities | Specialized personas |
+| **Context** | Main conversation | Optional fork | Always forked |
+| **Best for** | Quick prompts | Complex workflows | Isolated tasks |
+
+---
+
+## Skills vs Rules
+
+| Aspect | Skills | Rules |
+|--------|--------|-------|
+| **Loading** | On-demand (lazy) | Always in context |
+| **Activation** | Probabilistic or explicit | Deterministic |
+| **Context cost** | Only paid when invoked | Always paid |
+| **Best for** | Task-specific procedures | Universal conventions |
+
+---
+
+## Best Practices
+
+1. **Keep SKILL.md focused**: Overview and quick reference only
+2. **Use progressive disclosure**: Link to detailed docs
+3. **Restrict tools**: Only grant necessary permissions
+4. **Make descriptions searchable**: Include keywords and use cases
+5. **Bundle scripts**: Include utility scripts in skill directory
+6. **Disable auto-invocation for dangerous ops**: `disable-model-invocation: true`
+
+---
+
+## Related
+
+- [commands.md](commands.md) - Simple slash commands
+- [agents.md](agents.md) - Isolated specialists
+- [rules.md](rules.md) - Always-on conventions

--- a/claude-code/knowledge-base/tools.md
+++ b/claude-code/knowledge-base/tools.md
@@ -1,0 +1,235 @@
+# Claude Code > Tools
+
+> Built-in tools available to Claude Code.
+
+## Core Tools
+
+| Tool | Purpose | Typical Use |
+|------|---------|-------------|
+| `Read` | Read file contents | Examine code, config, docs |
+| `Write` | Create/overwrite files | New files, full replacements |
+| `Edit` | Modify file sections | Targeted changes, refactoring |
+| `Glob` | Find files by pattern | `**/*.ts`, `src/**/*.py` |
+| `Grep` | Search file contents | Find patterns, usages |
+| `Bash` | Execute shell commands | Git, npm, build tools |
+| `Task` | Spawn subagent | Delegate to specialists |
+| `WebFetch` | Fetch URL content | Documentation, APIs |
+| `WebSearch` | Search the web | Current information |
+
+## Read-Only Tools
+
+| Tool | Description |
+|------|-------------|
+| `Read` | Read file contents (supports images, PDFs, notebooks) |
+| `Glob` | Match files by glob pattern |
+| `Grep` | Search with regex (ripgrep-based) |
+
+## Modification Tools
+
+| Tool | Description |
+|------|-------------|
+| `Write` | Create new files or overwrite existing |
+| `Edit` | Replace specific text in files |
+| `NotebookEdit` | Edit Jupyter notebook cells |
+
+## Execution Tools
+
+| Tool | Description |
+|------|-------------|
+| `Bash` | Execute shell commands with timeout |
+| `Task` | Spawn isolated subagent for complex tasks |
+
+## Network Tools
+
+| Tool | Description |
+|------|-------------|
+| `WebFetch` | Fetch and process web content |
+| `WebSearch` | Search the web for information |
+
+## Interaction Tools
+
+| Tool | Description |
+|------|-------------|
+| `AskUserQuestion` | Present choices to user |
+| `EnterPlanMode` | Switch to read-only planning |
+| `ExitPlanMode` | Signal plan completion |
+
+---
+
+## Tool Details
+
+### Read
+
+Reads file contents with line numbers.
+
+```
+Read(file_path, offset?, limit?)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `file_path` | Absolute path to file |
+| `offset` | Line number to start (optional) |
+| `limit` | Number of lines to read (optional) |
+
+**Supports**: Code, text, images (PNG, JPG), PDFs, Jupyter notebooks (.ipynb)
+
+### Write
+
+Creates or overwrites a file completely.
+
+```
+Write(file_path, content)
+```
+
+**Note**: Prefer `Edit` for modifications to existing files.
+
+### Edit
+
+Replaces specific text in a file.
+
+```
+Edit(file_path, old_string, new_string, replace_all?)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `file_path` | Absolute path to file |
+| `old_string` | Text to find and replace |
+| `new_string` | Replacement text |
+| `replace_all` | Replace all occurrences (default: false) |
+
+**Note**: `old_string` must be unique in the file, or use `replace_all: true`.
+
+### Glob
+
+Finds files matching a glob pattern.
+
+```
+Glob(pattern, path?)
+```
+
+| Pattern | Matches |
+|---------|---------|
+| `**/*.ts` | All TypeScript files |
+| `src/**/*.py` | Python files in src/ |
+| `*.md` | Markdown in current dir |
+| `{src,lib}/**` | Files in src/ or lib/ |
+
+### Grep
+
+Searches file contents with regex.
+
+```
+Grep(pattern, path?, glob?, output_mode?)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `pattern` | Regex pattern to search |
+| `path` | Directory to search (default: cwd) |
+| `glob` | Filter files by glob |
+| `output_mode` | `content`, `files_with_matches`, `count` |
+
+**Context options**: `-A` (after), `-B` (before), `-C` (around)
+
+### Bash
+
+Executes shell commands.
+
+```
+Bash(command, description?, timeout?, run_in_background?)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `command` | Shell command to execute |
+| `description` | What the command does |
+| `timeout` | Max milliseconds (default: 120000) |
+| `run_in_background` | Run async (default: false) |
+
+**Note**: Use dedicated tools (Read, Edit, Grep) instead of shell equivalents.
+
+### Task
+
+Spawns an isolated subagent.
+
+```
+Task(prompt, subagent_type, description, model?, run_in_background?)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `prompt` | Instructions for the subagent |
+| `subagent_type` | Agent type (e.g., `Explore`, `Plan`) |
+| `description` | Short description (3-5 words) |
+| `model` | `sonnet`, `opus`, `haiku` |
+| `run_in_background` | Run async |
+
+### AskUserQuestion
+
+Presents choices to the user.
+
+```
+AskUserQuestion(questions)
+```
+
+Each question has:
+- `question`: The question text
+- `header`: Short label (max 12 chars)
+- `options`: 2-4 choices with label and description
+- `multiSelect`: Allow multiple selections
+
+---
+
+## Tool Availability by Mode
+
+| Tool | Default | Plan Mode | Sandboxed |
+|------|---------|-----------|-----------|
+| Read | Yes | Yes | Yes |
+| Glob | Yes | Yes | Yes |
+| Grep | Yes | Yes | Yes |
+| Edit | Yes | **No** | Yes |
+| Write | Yes | **No** | Yes |
+| Bash | Yes | **No** | Restricted |
+| WebFetch | Yes | **No** | Depends |
+| WebSearch | Yes | **No** | Depends |
+| Task | Yes | Yes | Yes |
+| AskUserQuestion | Yes | Yes | Yes |
+
+---
+
+## Permission Patterns
+
+Control tool access in `settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm:*)",
+      "Read(./src/**)",
+      "Edit(./src/**/*.ts)"
+    ],
+    "deny": [
+      "Bash(rm -rf:*)",
+      "Read(.env*)"
+    ]
+  }
+}
+```
+
+| Pattern | Matches |
+|---------|---------|
+| `Tool` | All uses of the tool |
+| `Tool(pattern)` | Uses matching pattern |
+| `Tool(prefix:*)` | Uses starting with prefix |
+| `Tool(./path/**)` | Path glob patterns |
+
+---
+
+## Related
+
+- [settings.md](settings.md) - Permission configuration
+- [permissions.md](permissions.md) - Permission modes
+- [hooks.md](hooks.md) - Intercept tool calls

--- a/claude-docs/subfolders/README.md
+++ b/claude-docs/subfolders/README.md
@@ -59,9 +59,11 @@ Comprehensive analysis of all configurable components in the Claude Code `.claud
 | **Objective** | Provide modular, file-type-specific coding standards and guidelines. Organize instructions by topic instead of one monolithic file |
 | **Context Management** | Loaded as **user context** like CLAUDE.md, but can be **path-filtered** via frontmatter globs. Only relevant rules load for current file context |
 | **Lifecycle Stage** | **Session start + context-aware** - all rules load at start, path-specific rules filter based on active files |
-| **Activation** | Automatic. Path-specific rules activate when working on matching files |
+| **Activation** | **Deterministic** — always present when session starts (unlike skills which are probabilistic) |
 
 **Key Insight**: Rules are "conditional CLAUDE.md" - they let you say "when working on `*.sol` files, follow these Solidity conventions" without cluttering context for other file types.
+
+**Important**: Rules are suggestions the LLM weighs against other context. For enforcement, use hooks.
 
 **Documentation**: [rules.md](rules.md)
 
@@ -89,9 +91,13 @@ Comprehensive analysis of all configurable components in the Claude Code `.claud
 | **Objective** | Define complex, multi-file capabilities that Claude can auto-discover and invoke when relevant. More powerful than commands |
 | **Context Management** | Skill instructions load into context when invoked. Can run in **forked context** (`context: fork`) to isolate from main conversation. Supports progressive disclosure via linked files |
 | **Lifecycle Stage** | **Auto-discovery + on-demand** - Claude can suggest skills based on task matching, or user invokes explicitly |
-| **Activation** | Automatic (Claude suggests when relevant) OR explicit (`/skill-name`). Description keywords drive auto-discovery |
+| **Activation** | **Soft** (probabilistic via description matching) OR **Strong** (explicit `/skill-name`). See activation model below |
 
 **Key Insight**: Skills are "intelligent capabilities" - unlike commands which are just prompt templates, skills can be auto-suggested, run isolated, and contain supporting files for complex workflows.
+
+**Activation Types**:
+- **Soft**: Claude *could* auto-invoke via description matching (probabilistic)
+- **Strong**: Explicitly referenced in agent .md or called by user (deterministic)
 
 **Documentation**: [skills.md](skills.md)
 
@@ -320,6 +326,48 @@ Comprehensive analysis of all configurable components in the Claude Code `.claud
 - Want isolation + tool restrictions → **Agent**
 - Want instructions in your conversation → **Skill** (no fork)
 - Want complex multi-file capability that runs isolated → **Skill** (with fork) + **Agent**
+
+
+### Agents vs Rules vs Skills
+
+#### Purpose & Propagation
+
+| Concept | Purpose | Propagation |
+|---------|---------|-------------|
+| **Rules** | Shared conventions, style guides, format requirements | Can propagate across agents |
+| **Skills** | On-demand procedures, task-specific workflows | Shared across agents (loaded when needed) |
+| **Agent Prompts** | Individual agent's specific role and capabilities | Agent-specific, don't propagate |
+
+#### Activation Model
+
+| Aspect | Rules | Skills | Agents |
+|--------|-------|--------|--------|
+| **Loading** | Always in context | On-demand (lazy) | On delegation |
+| **Activation** | Deterministic | Probabilistic (soft) or Explicit (strong) | Task-matching or explicit |
+| **Context cost** | Always paid | Only when invoked | Isolated (own context) |
+| **Trigger** | Automatic | Description match OR `/skill` | Claude delegates OR user requests |
+
+#### Activation Types for Skills
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Soft** | Claude *could* auto-invoke via description matching | Task mentions "deploy" → deploy skill suggested |
+| **Strong** | Explicitly referenced in agent .md or called by user | `/deploy` or agent prompt says "use deploy skill" |
+| **Where** | Location where the skill is defined | `skills/deploy/SKILL.md` |
+
+#### Key Insight
+
+> **Rules are suggestions. Hooks are enforcement.**
+>
+> A rule saying "don't edit .env" is parsed by Claude and *maybe* followed.
+> A PreToolUse hook blocking .env edits *always* runs and blocks the operation.
+
+#### References
+
+- [User-Level Agent Rules Feature Request](https://github.com/anthropics/claude-code/issues/8395) — Discusses rule propagation to subagents
+- [Official Skill Creator](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md) — SKILL.md format and activation
+- [Bug: Claude ignores CLAUDE.md rules](https://github.com/anthropics/claude-code/issues/19635) — Rules are suggestions, not enforcement
+- [Skills Activation Discussion](https://github.com/orgs/community/discussions/182117) — Deterministic vs probabilistic retrieval
 
 ---
 

--- a/claude-docs/subfolders/rules.md
+++ b/claude-docs/subfolders/rules.md
@@ -317,6 +317,52 @@ Each rule file should cover ONE topic. This makes them:
 
 **Recommendation**: Use `CLAUDE.md` for high-level project context and `.claude/rules/` for detailed coding standards.
 
+## Rules vs Skills: Activation Model
+
+Rules and skills differ fundamentally in how they are activated:
+
+| Aspect | Rules | Skills |
+|--------|-------|--------|
+| **Loading** | Always in context when session starts | On-demand (lazy loading) |
+| **Activation** | Deterministic — always present | Probabilistic — description matching or explicit call |
+| **Context cost** | Always paid (always loaded) | Only paid when invoked |
+| **Best for** | Universal conventions, format constraints | Task-specific procedures |
+
+### Key Insight
+
+> **Rules are suggestions that the LLM weighs against other context. Hooks are enforcement.**
+>
+> A rule saying "don't edit .env" is parsed by Claude and *maybe* followed. A PreToolUse hook blocking .env edits *always* runs and blocks the operation.
+
+### Activation Types for Skills
+
+Skills can have different activation modes:
+
+| Activation | Description |
+|------------|-------------|
+| **Soft** | Claude *could* auto-invoke via description matching (probabilistic) |
+| **Strong** | Explicitly referenced in agent .md or called by user (deterministic) |
+
+### Where Rules and Skills Are Defined
+
+| Type | Location | Example |
+|------|----------|---------|
+| Rules (project) | `.claude/rules/*.md` | `.claude/rules/code-style.md` |
+| Rules (user) | `~/.claude/rules/*.md` | `~/.claude/rules/my-conventions.md` |
+| Rules (embedded) | Inside agent `.md` files | Agent-specific constraints |
+| Skills (project) | `.claude/skills/*/SKILL.md` | `.claude/skills/deploy/SKILL.md` |
+| Skills (user) | `~/.claude/skills/*/SKILL.md` | `~/.claude/skills/commit-helper/SKILL.md` |
+
+### When to Use Each
+
+| Scenario | Use |
+|----------|-----|
+| Coding standards that always apply | Rule |
+| Format constraints for agent output | Rule (embedded in agent .md) |
+| Procedure invoked on specific tasks | Skill (soft activation) |
+| Workflow explicitly triggered by user | Skill (strong activation, `/skill-name`) |
+| Safety guardrails that must be enforced | Hook (not rule) |
+
 ## Loading Behavior
 
 - All rules in `.claude/rules/` are loaded at session start

--- a/claude-docs/subfolders/skills.md
+++ b/claude-docs/subfolders/skills.md
@@ -385,6 +385,58 @@ description: Reviews pull requests for code quality, security issues, performanc
 ---
 ```
 
+## Skills vs Rules: Activation Model
+
+Skills and rules differ fundamentally in how they are activated:
+
+| Aspect | Skills | Rules |
+|--------|--------|-------|
+| **Loading** | On-demand (lazy loading) | Always in context |
+| **Activation** | Probabilistic (description matching) or explicit (`/skill`) | Deterministic — always present |
+| **Context cost** | Only paid when invoked | Always paid |
+| **Best for** | Task-specific procedures | Universal conventions, format constraints |
+
+### Activation Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Soft** | Claude *could* auto-invoke via description matching | Task mentions "deploy" → deploy skill suggested |
+| **Strong** | Explicitly referenced in agent .md or called by user | `/deploy` or agent prompt says "use deploy skill" |
+
+### Soft vs Strong Activation
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     SKILL ACTIVATION                             │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  SOFT (probabilistic)              STRONG (deterministic)        │
+│  ┌─────────────────────┐          ┌─────────────────────┐       │
+│  │ User says "deploy"  │          │ User types /deploy  │       │
+│  │         ↓           │          │         ↓           │       │
+│  │ Claude checks       │          │ Skill loads         │       │
+│  │ skill descriptions  │          │ immediately         │       │
+│  │         ↓           │          │                     │       │
+│  │ Maybe suggests      │          │                     │       │
+│  │ deploy skill        │          │                     │       │
+│  └─────────────────────┘          └─────────────────────┘       │
+│                                                                  │
+│  • May not trigger                 • Always triggers             │
+│  • Depends on description          • Explicit invocation         │
+│  • Context-dependent               • User-controlled             │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### When to Use Soft vs Strong
+
+| Scenario | Activation | Why |
+|----------|------------|-----|
+| Common workflow user will remember | Strong (`/skill`) | Explicit, predictable |
+| Context-dependent procedure | Soft (auto-discovery) | Claude decides when relevant |
+| Background reference material | Soft + `user-invocable: false` | Claude uses, user doesn't invoke |
+| Dangerous operations (deploy, delete) | Strong + `disable-model-invocation: true` | Prevent accidental triggering |
+
 ## Hooks in Skills
 
 ```yaml

--- a/commands/alto-gitops.md
+++ b/commands/alto-gitops.md
@@ -1,28 +1,26 @@
 ---
 name: alto-gitops
-description: Handles branch/commit/push hygiene. Use after a task passes checks.
-tools: Read, Grep, Glob, LS, Bash
-model: opus
-permissionMode: default
-skills: alto-protocol, handoff-writing
+description: Handles branch/commit/push hygiene after a task passes checks.
+allowed-tools:
+  - Read
+  - Bash
 ---
 
-You are the GITOPS agent.
+# GitOps Command
 
-## IMPORTANT: Efficiency
-- Read task file + handoff to get summary for commit message
-- Run git commands: status, add, commit
-- Write your handoff
-- Done. No exploration needed.
+Run git operations for the current task.
 
-You MUST:
-- Read `runs/state.json` to get `current_handoff` path
-- Read the task file + role agent's handoff (at `current_handoff`)
-- Ensure a branch exists (create/switch only if task requires).
-- Stage and commit ALL changes using conventional commits format.
-- Push only if explicitly allowed by permissions or the user approves.
+## Steps
+
+1. Read `runs/state.json` to get `current_handoff` path
+2. Read the task file + role agent's handoff (at `current_handoff`)
+3. Run `git status` to see all changes
+4. Run `git add -A` to stage all changes (tracked and untracked)
+5. Create commit using conventional commits format
+6. Write handoff to `runs/handoffs/task-{ID}-gitops.md`
 
 ## Conventional Commits Format
+
 ```
 <type>(<scope>): <short summary>
 
@@ -47,16 +45,18 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
 ## Git Operations
+
 1. Run `git status` to see all changes
-2. Run `git add -A` to stage all changes (tracked and untracked)
+2. Run `git add -A` to stage all changes
 3. Run `git commit` with conventional commit message (use heredoc for multiline)
 4. Do NOT push - commits stay local until user requests push
 
 ## Handoff Output
-Derive your handoff path per `.claude/skills/handoff-writing/SKILL.md` Post-Agent section:
+
+Derive handoff path from `current_handoff`:
 - `current_handoff`: `runs/handoffs/task-005.md` → yours: `runs/handoffs/task-005-gitops.md`
 
-Use **exactly** these section headers (required by validation):
+Use **exactly** these section headers:
 - `## Summary` - Commit hash, branch name, what was committed
 - `## Files Touched` - Files included in commit (summary)
 - `## How to Verify` - `git log -1` or `git show <hash>`

--- a/devenv.nix
+++ b/devenv.nix
@@ -876,13 +876,7 @@ STATE_EOF
           permissionMode = cfg.agentPermissions.alto-docs.permissionMode;
           prompt = readAgentPrompt "alto-docs";
         };
-        alto-gitops = {
-          description = "Handles branch/commit/push hygiene. Use after a task passes checks.";
-          tools = cfg.agentPermissions.alto-gitops.tools;
-          model = "opus";
-          permissionMode = cfg.agentPermissions.alto-gitops.permissionMode;
-          prompt = readAgentPrompt "alto-gitops";
-        };
+        # NOTE: alto-gitops is now a command (see commands/alto-gitops.md)
         alto-reviewer = {
           description = "Reviews code quality after role agent completes. Can reject back to role agent.";
           tools = cfg.agentPermissions.alto-reviewer.tools;

--- a/hooks/tool-use-record.py
+++ b/hooks/tool-use-record.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-"""Stub - this hook was replaced by tool-record.py (PostToolUse)."""
-import sys
-import json
-# Just consume stdin and exit
-json.load(sys.stdin)

--- a/rules/alto-development.md
+++ b/rules/alto-development.md
@@ -1,0 +1,160 @@
+# ALTO Development Rules
+
+> Distilled rules for ALTO dev mode based on Claude Code best practices research.
+
+---
+
+## Rule 1: Rule Placement
+
+**Trigger**: Writing a new rule for agent behavior
+
+**Action**:
+- Single agent only → embed in that agent's `.md` file
+- Multiple agents → create `rules/*.md` file
+
+**Rationale**: Reduces context bloat; rules always load for their scope.
+
+---
+
+## Rule 2: Feature Selection Matrix
+
+**Trigger**: Deciding between rule, skill, hook, or command
+
+**Action**: Use this matrix:
+
+| Need | Use | Why |
+|------|-----|-----|
+| Always-active constraint | Rule | Deterministic, always in context |
+| On-demand procedure | Skill | Lazy loading, saves baseline context |
+| Must enforce (block/log) | Hook | Always executes, can't be ignored |
+| User-triggered shortcut | Command | Explicit invocation, simple template |
+| Warn user (not Claude) | Hook warn | Warn only reaches user, not Claude |
+
+**Rationale**: Context budget is finite (~180k usable); wrong choice wastes tokens.
+
+---
+
+## Rule 3: CLAUDE.md/Agent.md Size Limits
+
+**Trigger**: Writing orchestrator templates or agent prompts
+
+**Action**:
+- Keep under 300 lines (60 lines ideal)
+- Use `file:line` references, not code snippets
+- Progressive disclosure: reference docs, don't embed
+
+**Rationale**: "May or may not be relevant" system message = non-universal rules get ignored.
+
+---
+
+## Rule 4: Provide Alternatives, Not Just Negatives
+
+**Trigger**: Writing any constraint or rule
+
+**Action**:
+- BAD: "Never use --foo-bar flag"
+- GOOD: "Use --baz instead of --foo-bar because X"
+
+**Rationale**: Agent gets stuck when it thinks it must use a forbidden thing but has no alternative.
+
+---
+
+## Rule 5: Don't Use LLM for Linter Work
+
+**Trigger**: Tempted to add style rules (formatting, naming)
+
+**Action**: Use deterministic tools (eslint, prettier, ruff, black) instead
+
+**Rationale**: LLMs are expensive/slow; linters are fast/reliable.
+
+---
+
+## Rule 6: Skill Activation Safety
+
+**Trigger**: Creating skill for dangerous operations (deploy, delete, reset)
+
+**Action**:
+```yaml
+---
+disable-model-invocation: true
+user-invocable: true
+---
+```
+
+**Rationale**: Prevents accidental triggering via description matching.
+
+---
+
+## Rule 7: Agent Path Restrictions
+
+**Trigger**: Creating task for implementation agent
+
+**Action**: Always include explicit `allowed_paths` in task frontmatter
+
+```yaml
+---
+allowed_paths:
+  - backend/**
+  - src/api/**
+---
+```
+
+**Rationale**: Prevents scope creep; agent can only touch relevant files.
+
+---
+
+## Rule 8: Hook Limitations Awareness
+
+**Trigger**: Designing hook-based validation
+
+**Action**: Know these limitations:
+
+| Limitation | Detail |
+|------------|--------|
+| PreToolUse cannot see result | Runs before tool executes |
+| PostToolUse cannot modify result | Already in context |
+| Warn messages only reach user | Claude doesn't see warn output |
+| Skill-scoped hooks may not trigger | Known issue in plugins |
+
+**Rationale**: Design around actual capabilities, not assumed ones.
+
+---
+
+## Rule 9: Context Management in Multi-Agent Systems
+
+**Trigger**: Designing orchestrator with multiple agents
+
+**Action**:
+- Use subagents for investigation (separate context window)
+- Keep handoffs concise (they enter next agent's context)
+- Clear context between unrelated tasks
+
+**Rationale**: 200k window, ~20k baseline; subagents prevent context pollution.
+
+---
+
+## Rule 10: Prompt Writing Discipline
+
+**Trigger**: Writing any ALTO prompt (templates, agents, skills)
+
+**Action**: Follow `rules/prompt-writing.md`:
+- Explicit tool names: `AskUserQuestion` not "ask user"
+- Explicit paths: `runs/state.json` not "state file"
+- Always specify `AskUserQuestion` with Header, Question, Options
+
+**Rationale**: Ambiguous prompts cause tool selection errors.
+
+---
+
+## Quick Reference
+
+| Don't | Do Instead |
+|-------|------------|
+| Embed code snippets | Use `file:line` references |
+| Add style rules | Use linters (prettier, ruff) |
+| Say "don't do X" | Say "do Y instead of X because Z" |
+| Auto-invoke dangerous skills | Set `disable-model-invocation: true` |
+| Let agents touch any file | Specify `allowed_paths` |
+| Assume hooks can modify results | Design for actual capabilities |
+| Write 500-line CLAUDE.md | Keep under 300 lines, reference docs |
+| Put universal rules in skills | Put in `rules/*.md` |

--- a/rules/formats/handoff.md
+++ b/rules/formats/handoff.md
@@ -1,6 +1,6 @@
 ---
-name: handoff-writing
-description: Use when completing a task and writing handoff documentation. Provides exact format required for runs/handoffs/*.md files.
+paths:
+  - "runs/handoffs/**"
 ---
 
 # Handoff Writing

--- a/rules/formats/review.md
+++ b/rules/formats/review.md
@@ -1,6 +1,6 @@
 ---
-name: review-writing
-description: Use when writing code review results. Provides exact format required for runs/review/*.md files with APPROVED/REJECTED status.
+paths:
+  - "runs/review/**"
 ---
 
 # Review Writing

--- a/rules/formats/task.md
+++ b/rules/formats/task.md
@@ -1,6 +1,6 @@
 ---
-name: task-writing
-description: Use when creating task files in runs/tasks/. Provides exact format required for task frontmatter and body sections.
+paths:
+  - "runs/tasks/**"
 ---
 
 # Task Writing

--- a/rules/prompt-writing.md
+++ b/rules/prompt-writing.md
@@ -1,8 +1,3 @@
----
-name: prompt-writing
-description: Use when writing or editing ALTO prompts - templates/CLAUDE.md.*, agents/*.md, or skills/*/SKILL.md. Rules for explicit tool references, paths, and user interactions.
----
-
 # Prompt Writing Discipline
 
 Rules for writing CLAUDE.md, agent prompts, and skills.

--- a/rules/scope-discipline.md
+++ b/rules/scope-discipline.md
@@ -1,8 +1,3 @@
----
-name: scope-discipline
-description: Use when implementing features, editing source code, or responding to task handoffs. Enforces doing exactly what was requested - no scope creep, no "while I'm here" additions.
----
-
 # Scope Discipline
 
 ## Hard Rule

--- a/scripts/alto-deploy.sh
+++ b/scripts/alto-deploy.sh
@@ -28,7 +28,6 @@ rm -rf .claude/skills/* .claude/rules/* .claude/commands/* 2>/dev/null || true
 # Deploy rules (always loaded at session start)
 # Global rules (no path targeting)
 cp "$ALTO_SRC"/rules/scope-discipline.md .claude/rules/ 2>/dev/null || true
-cp "$ALTO_SRC"/rules/prompt-writing.md .claude/rules/ 2>/dev/null || true
 # Path-targeted format rules
 cp "$ALTO_SRC"/rules/formats/*.md .claude/rules/formats/ 2>/dev/null || true
 
@@ -46,9 +45,10 @@ if [ "$ORCHESTRATOR" != "dev" ]; then
   cp -r "$ALTO_SRC"/skills/alto-configure .claude/skills/ 2>/dev/null || true
 fi
 
-# Copy dev-specific skills (dev orchestrator only)
-# NOTE: prompt-writing is now a rule
+# Copy dev-specific skills and rules (dev orchestrator only)
 if [ "$ORCHESTRATOR" = "dev" ]; then
+  cp "$ALTO_SRC"/rules/prompt-writing.md .claude/rules/ 2>/dev/null || true
+  cp "$ALTO_SRC"/rules/alto-development.md .claude/rules/ 2>/dev/null || true
   cp -r "$ALTO_SRC"/skills/alto-dev-guide .claude/skills/ 2>/dev/null || true
   cp -r "$ALTO_SRC"/skills/writing-alto-skills .claude/skills/ 2>/dev/null || true
   cp -r "$ALTO_SRC"/skills/alto-self-fix .claude/skills/ 2>/dev/null || true

--- a/scripts/alto-deploy.sh
+++ b/scripts/alto-deploy.sh
@@ -16,35 +16,42 @@
 #   PLANNING_ARCHITECT_MODEL - Model for architecture phase
 #   PLANNING_PLANNER_MODEL - Model for planner agent
 
-# Create .claude directory for hooks and skills
-mkdir -p .claude/hooks .claude/skills
+# Create .claude directory for hooks, skills, rules, and commands
+mkdir -p .claude/hooks .claude/skills .claude/rules/formats .claude/commands
 
 # Copy hook scripts (referenced by native hook commands)
 cp -r "$ALTO_SRC"/hooks/*.py .claude/hooks/ 2>/dev/null || true
 
-# Remove old skills before copying (they're read-only from nix store)
-rm -rf .claude/skills/* 2>/dev/null || true
+# Remove old skills/rules/commands before copying (they're read-only from nix store)
+rm -rf .claude/skills/* .claude/rules/* .claude/commands/* 2>/dev/null || true
+
+# Deploy rules (always loaded at session start)
+# Global rules (no path targeting)
+cp "$ALTO_SRC"/rules/scope-discipline.md .claude/rules/ 2>/dev/null || true
+cp "$ALTO_SRC"/rules/prompt-writing.md .claude/rules/ 2>/dev/null || true
+# Path-targeted format rules
+cp "$ALTO_SRC"/rules/formats/*.md .claude/rules/formats/ 2>/dev/null || true
+
+# Deploy commands (explicit /invoke)
+cp "$ALTO_SRC"/commands/*.md .claude/commands/ 2>/dev/null || true
 
 # Copy skills available to all orchestrators
 cp -r "$ALTO_SRC"/skills/alto-switch .claude/skills/ 2>/dev/null || true
 
 # Copy shared ALTO skills (setup and build orchestrators)
+# NOTE: handoff-writing, task-writing, review-writing, scope-discipline are now rules
 if [ "$ORCHESTRATOR" != "dev" ]; then
   cp -r "$ALTO_SRC"/skills/alto-protocol .claude/skills/ 2>/dev/null || true
   cp -r "$ALTO_SRC"/skills/alto-feature-setup .claude/skills/ 2>/dev/null || true
   cp -r "$ALTO_SRC"/skills/alto-configure .claude/skills/ 2>/dev/null || true
-  cp -r "$ALTO_SRC"/skills/handoff-writing .claude/skills/ 2>/dev/null || true
-  cp -r "$ALTO_SRC"/skills/task-writing .claude/skills/ 2>/dev/null || true
-  cp -r "$ALTO_SRC"/skills/review-writing .claude/skills/ 2>/dev/null || true
-  cp -r "$ALTO_SRC"/skills/scope-discipline .claude/skills/ 2>/dev/null || true
 fi
 
 # Copy dev-specific skills (dev orchestrator only)
+# NOTE: prompt-writing is now a rule
 if [ "$ORCHESTRATOR" = "dev" ]; then
   cp -r "$ALTO_SRC"/skills/alto-dev-guide .claude/skills/ 2>/dev/null || true
   cp -r "$ALTO_SRC"/skills/writing-alto-skills .claude/skills/ 2>/dev/null || true
   cp -r "$ALTO_SRC"/skills/alto-self-fix .claude/skills/ 2>/dev/null || true
-  cp -r "$ALTO_SRC"/skills/prompt-writing .claude/skills/ 2>/dev/null || true
   cp -r "$ALTO_SRC"/skills/alto-test-protocol .claude/skills/ 2>/dev/null || true
 fi
 

--- a/templates/CLAUDE.md.build
+++ b/templates/CLAUDE.md.build
@@ -164,7 +164,7 @@ Repeat until `alto-status` shows `>>> FEATURE COMPLETE <<<`:
    - Update state.json: `phase = "IN_TASK"`, `current_role`, `current_handoff`
    - (Hook auto-creates handoff template when state.json is saved)
 
-4. **Execute** — Invoke role agent via Task tool. Agent uses `.claude/skills/handoff-writing/SKILL.md` for handoff format.
+4. **Execute** — Invoke role agent via Task tool. Agent uses `.claude/rules/formats/handoff.md` for handoff format.
 
 5. **Post agents** — Run task's `post` array (e.g., alto-qa, alto-gitops)
 


### PR DESCRIPTION
## Summary

Reorganizes ALTO's skills, agents, and hooks according to Claude Code's native concepts (Rules, Commands, Skills, Agents) based on the 3-axis model:

- **Input**: No Context ↔ Full Context
- **Output**: Deterministic ↔ Judgment
- **Process**: Atomic ↔ Compound

### Changes

**Added Claude Code Knowledge Base** (`claude-code/knowledge-base/`):
- 15 AI-optimized markdown files (~4160 lines total)
- `index.md` — Navigation hub with feature matrix and selection guide
- `overview.md` — Context flow diagrams, lifecycle, "what affects what"
- Core features: `tools.md`, `settings.md`, `memory.md`, `permissions.md`
- Extensions: `rules.md`, `commands.md`, `skills.md`, `agents.md`, `hooks.md`
- Supporting: `mcp.md`, `plan-mode.md`, `output-styles.md`, `quick-reference.md`

**Added ALTO Development Rules** (`rules/alto-development.md`):
- 10 distilled rules for dev mode based on Claude Code best practices research
- Feature selection matrix (rule vs skill vs hook vs command)
- CLAUDE.md size limits and prompt writing discipline
- Hook limitations awareness, skill activation safety

**Added PROTOCOL.md** — Action classification and execution model:
- Hierarchical indexing for actions (10, 10.1, 10.2, etc.)
- Agent categories table (impl, tester, reviewer, controller, planner, support)
- Column reference (Type, Executor, Triggerer)
- Triggerer semantics (event, user, self, parent, #index)
- Passive Constraints with activation model (Soft/Strong/Where)
- Rules vs Skills comparison

**Updated claude-docs** with activation model documentation:
- `rules.md` — Rules vs Skills activation comparison
- `skills.md` — Soft vs Strong activation diagram
- `README.md` — Comprehensive Agents vs Rules vs Skills comparison with GitHub references

**Migrated to Rules** (`.claude/rules/`, always loaded at session start):
- `scope-discipline.md` - Global constraint rule
- `prompt-writing.md` - Prompt writing discipline
- `formats/handoff.md` - Path-targeted for `runs/handoffs/**`
- `formats/task.md` - Path-targeted for `runs/tasks/**`
- `formats/review.md` - Path-targeted for `runs/review/**`

**Converted to Command** (`.claude/commands/`, explicit `/invoke`):
- `alto-gitops.md` - Was deterministic+atomic agent, now explicit command

**Removed**:
- `agents/alto-gitops.md` - Converted to command
- `hooks/tool-use-record.py` - Deprecated stub
- 5 skill directories migrated to rules

**Updated**:
- ARCHITECTURE.md now references PROTOCOL.md
- All agent references now use `.claude/rules/formats/*.md`
- `alto-deploy.sh` copies rules and commands directories, plus alto-development.md in dev mode
- CHANGELOG.md with migration notes

## Test plan
- [ ] Run `nix-instantiate --parse devenv.nix` - validates Nix syntax
- [ ] Run `python3 -m py_compile hooks/*.py` - validates Python syntax
- [ ] Test in fresh consumer project with `devenv shell`
- [ ] Verify `.claude/rules/` and `.claude/commands/` are deployed
- [ ] Verify agents still receive handoff/task/review formats via rules
- [ ] Verify PROTOCOL.md tables render correctly
- [ ] Verify `claude-code/knowledge-base/` files have no broken links